### PR TITLE
Update PrintNightmare.yaml

### DIFF
--- a/content/exchange/artifacts/PrintNightmare.yaml
+++ b/content/exchange/artifacts/PrintNightmare.yaml
@@ -3,10 +3,10 @@ author: "Matt Green - @mgreen27"
 description: |
   This artifact returns any binaries in the Windows/spool/drivers/** folders with
   an untrusted Authenticode entry.
-
-  It can be used to hunt for dll files droped during exploitation of
+  
+  It can be used to hunt for dll files droped during exploitation of 
   CVE-2021-1675 - PrintNightmare.
-
+  
   To query all attached ntfs drives: check the AllDrives switch.
 
   I have added several filters to uplift search capabilities from the original
@@ -19,7 +19,6 @@ description: |
   - Time bounds to select files with a timestamp within time ranges
   - FileSize bounds
 
-  ![Sample output](https://user-images.githubusercontent.com/13081800/124166265-f2c08000-dae5-11eb-9359-ce7f80c1a10c.png)
 
 parameters:
   - name: MFTFilename
@@ -33,6 +32,9 @@ parameters:
   - name: FileRegex
     description: "Regex search over File Name"
     default: .
+  - name: AllAuthenticode
+    type: bool
+    description: "Show all binaries despite Authenticode trusted status (default shows only untrusted)."
   - name: DateAfter
     type: timestamp
     description: "search for events after this date. YYYY-MM-DDTmm:hh:ssZ"
@@ -53,13 +55,13 @@ parameters:
 sources:
   - query: |
       -- time testing
-      LET time_test(stamp) =
+      LET time_test(stamp) = 
             if(condition= DateBefore AND DateAfter,
                 then= stamp < DateBefore AND stamp > DateAfter,
-                else=
+                else= 
             if(condition=DateBefore,
                 then= stamp < DateBefore,
-                else=
+                else= 
             if(condition= DateAfter,
                 then= stamp > DateAfter,
                 else= True
@@ -72,7 +74,7 @@ sources:
 
 
       -- function returning MFT entries
-      LET mftsearch(MFTPath) = SELECT
+      LET mftsearch(MFTPath) = SELECT 
             split(sep='\\$',string=MFTPath)[0] + FullPath as FullPath,
             InUse,FileName,FileSize,
             dict(
@@ -97,7 +99,7 @@ sources:
             AND if(condition=SizeMin,
                 then=FileSize > atoi(string=SizeMin),
                 else=TRUE)
-            AND
+            AND 
              ( time_test(stamp=Created0x10)
             OR time_test(stamp=Created0x30)
             OR time_test(stamp=LastModified0x10)
@@ -127,4 +129,7 @@ sources:
         else= {
            SELECT * FROM mftsearch(MFTPath=MFTFilename)
         })
-      WHERE PE AND NOT Authenticode.Trusted = 'trusted'
+      WHERE PE
+        AND if(condition=AllAuthenticode,
+            then=TRUE,
+            else= NOT Authenticode.Trusted = 'trusted')


### PR DESCRIPTION
Add in option to show Authenticode 'Trusted' binaries. In some cases we would want to check Trusted binaries as tools like mimikatz is EV signed.
![image](https://user-images.githubusercontent.com/13081800/124533747-45879800-de56-11eb-9b78-b67e5b154de0.png)
