### PR TITLE
Create PrintSpoolerRemediation.yaml

### DIFF
--- a/content/exchange/artifacts/PrintSpoolerRemediation.yaml
+++ b/content/exchange/artifacts/PrintSpoolerRemediation.yaml
@@ -9,10 +9,10 @@ description: |
      - disabling the print spooler service.   
      HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler\Start = 4 (service disabled).   
          
-     - disable registration of the spool service.    
+     - disable remote registration of the spool service.    
      HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint = 2 (RegisterSpoolerRemoteRpcEndPoint disables).  
    
-   NOTE: ChangeServiceStartup will set to disabkle, not stop the printspool service. 
+   NOTE: ChangeServiceStartup will set to disable, not stop the printspool service. 
    Its always reccomended to use group policy to deploy these settings. This 
    artifact will disable 
    

--- a/content/exchange/artifacts/PrintSpoolerRemediation.yaml
+++ b/content/exchange/artifacts/PrintSpoolerRemediation.yaml
@@ -1,0 +1,63 @@
+name: Windows.Remediation.PrintSpooler
+author: Matt Green - @mgreen27
+description: |
+   This artifact will enable mitigation of PrintSpooler exploitation used by 
+   PrintNightmare - CVE-2021-34527 and CVE-2021-1675.
+   
+   There are two selectable mitigations:  
+     
+     - disabling the print spooler service.   
+     HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler\Start = 4 (service disabled).   
+         
+     - disable registration of the spool service.    
+     HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint = 2 (RegisterSpoolerRemoteRpcEndPoint disables).  
+   
+   NOTE: ChangeServiceStartup will set to disabkle, not stop the printspool service. 
+   Its always reccomended to use group policy to deploy these settings. This 
+   artifact will disable 
+   
+   
+type: CLIENT
+
+parameters:
+ - name: TargetGlobs
+   type: csv
+   default: |
+    Target,Description,Potential Values
+    HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler\Start,Print spooler service startup,"0 = Boot, 1 = System, 2 = Automatic, 3 = Manual, 4 = Disabled"
+    HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint,Print spooler RemoteRpcEndPoint registration,"Enabled = 1, Disabled = 2"
+    HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint,Print spooler RemoteRpcEndPoint registration WOW6432Node,"Enabled = 1, Disabled = 2"
+ - name: MitigateServiceStartup
+   type: bool
+ - name: MitigateRegisterSpoolerRemoteRpcEndPoint
+   type: bool
+
+sources:
+  - query: |
+      -- remediation template
+      LET execute_reg(key,name,value) = SELECT * FROM execve(argv=['reg','add',key,'/v',name,'/t','REG_DWORD','/d',value,'/f'])
+      LET Arch = SELECT PROCESSOR_ARCHITECTURE FROM environ()
+      
+      LET remediation <= SELECT * FROM chain(
+            a=if(condition=MitigateServiceStartup,
+                then = execute_reg(key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Spooler',name='Start',value=4)),
+            b= if(condition=MitigateRegisterSpoolerRemoteRpcEndPoint,
+                then= execute_reg(key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Printers',name='RegisterSpoolerRemoteRpcEndPoint',value=2)),
+            c= if(condition=MitigateRegisterSpoolerRemoteRpcEndPoint,
+                then= if(condition= Arch.PROCESSOR_ARCHITECTURE[0]='AMD64',
+                    then= execute_reg(key='HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Policies\\Microsoft\\Windows NT\\Printers',name='RegisterSpoolerRemoteRpcEndPoint',value=2)))
+            )
+      
+      SELECT * FROM foreach(row=TargetGlobs,
+        query={
+            SELECT
+                Description,
+                `Potential Values`,
+                mtime as ModifiedTime,FullPath,
+                basename(path=FullPath) as KeyName,
+                Data.type as KeyType,
+                Data.value as KeyValue
+            FROM glob(globs=Target, accessor="reg")
+        })
+        
+      


### PR DESCRIPTION
This artifact will enable mitigation of PrintSpooler exploitation used by 
   PrintNightmare - CVE-2021-34527 and CVE-2021-1675.
   
   There are two selectable mitigations:  
     
     - disabling the print spooler service.   
     HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler\Start = 4 (service disabled).   
         
     - disable registration of the spool service.    
     HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RegisterSpoolerRemoteRpcEndPoint = 2 (RegisterSpoolerRemoteRpcEndPoint disables).  
   
   NOTE: ChangeServiceStartup will set to disabkle, not stop the printspool service. 
   Its always reccomended to use group policy to deploy these settings. This 
   artifact will disable 

![image](https://user-images.githubusercontent.com/13081800/124555299-4a5e4300-de7a-11eb-8959-826c57d0cdf2.png)
