### PR TITLE
Create PrintNightmareMonitor.yaml

### DIFF
--- a/content/exchange/artifacts/PrintNightmareMonitor.yaml
+++ b/content/exchange/artifacts/PrintNightmareMonitor.yaml
@@ -1,0 +1,53 @@
+name: Windows.Monitoring.PrintNightmare
+author: Matt Green - @mgreen27
+description: |
+  This artifact returns ETW PrintService events for potential PrintNightmare activity.  
+  CVE-2021-1675 and CVE-2021-34527
+  
+  It monitors for DRIVER_ADDED events and enriches with binary informaiton for 
+  payload DataFile. Hunt for unexpected drivers with malicous DataFiles.
+  
+type: CLIENT_EVENT
+sources:
+  - query: |
+      -- Monitor ETW provider and extract enriched target events
+      LET hits = SELECT
+            System.TimeStamp AS EventTime,
+            "Microsoft-Windows-PrintService" as Provider,
+            System.ID as EventId,
+            'DRIVER_ADDED' as Action,
+            EventData,
+            {
+                SELECT 
+                    split(string=Name, sep=',')[0] as Name,
+                    SupportedPlatform,
+                    Version,
+                    DriverPath,
+                    ConfigFile,
+                    DataFile
+                  FROM wmi(query='SELECT * FROM Win32_PrinterDriver',namespace='root/CIMV2')
+                  WHERE Name = EventData.param1
+            } as DriverInformation
+        FROM watch_etw(guid="{747EF6FD-E535-4D16-B510-42C90F6873A1}",
+            name=format(format="Velociraptor-%v-PrintService", args=now()))
+        WHERE EventId = 316
+
+      -- output rows and final binary enrichment
+      SELECT
+        EventTime,
+        Provider,
+        EventId,
+        Action,
+        EventData.param1 as Name,
+        EventData.param2 as Platform,
+        DriverInformation.Version as Version,
+        if(condition=DriverInformation,
+            then= dict(
+                DriverPath=DriverInformation.DriverPath,
+                ConfigFile=DriverInformation.ConfigFile,
+                DataFile=DriverInformation.DataFile),
+            else= EventData.param4) as Files,
+        hash(path=DriverInformation.DataFile) as DataFileHash,
+        parse_pe(file=DriverInformation.DataFile) as DataFilePE,
+        authenticode(filename=DriverInformation.DataFile) as DataFileAuthenticode
+      FROM hits

--- a/content/exchange/artifacts/PrintNightmareMonitor.yaml
+++ b/content/exchange/artifacts/PrintNightmareMonitor.yaml
@@ -2,10 +2,10 @@ name: Windows.Monitoring.PrintNightmare
 author: Matt Green - @mgreen27
 description: |
   This artifact returns ETW PrintService events for potential PrintNightmare activity.  
-  CVE-2021-1675 and CVE-2021-34527
+  CVE-2021-1675 and CVE-2021-34527  
   
-  It monitors for DRIVER_ADDED events and enriches with binary informaiton for 
-  payload DataFile. Hunt for unexpected drivers with malicous DataFiles.
+  It monitors for DRIVER_ADDED events and enriches with binary information for payload 
+  DataFile. Hunt for unexpected drivers with malicious DataFiles.
   
 type: CLIENT_EVENT
 sources:


### PR DESCRIPTION
This artifact returns ETW PrintService events for potential PrintNightmare activity.  
CVE-2021-1675 and CVE-2021-34527
  
It monitors for DRIVER_ADDED events and enriches with binary information for payload DataFile. Hunt for unexpected drivers with malicious DataFiles.
  
![image](https://user-images.githubusercontent.com/13081800/124857458-b57d5600-dfef-11eb-96cc-81afc63bcd6d.png)
