### PR TITLE
Patch 4

### DIFF
--- a/content/docs/overview/deployment/_index.md
+++ b/content/docs/overview/deployment/_index.md
@@ -5,162 +5,64 @@ draft: false
 weight: 2
 ---
 
-Velociraptor can be deployed in a number of scenarios depending on
-need. The diagram below illustrates what a typical Velociraptor deployment looks like.
+You can deploy full-scale Velociraptor using either the [SSL-Self Signed](self-signed) or [Cloud Deployment](cloud) method, or set up a Velolicraptor environment on your local machine for testing environment. For more information, see [Instant Velociraptor](#instant-velociraptor).  
 
-![Deployment Overview](overview.png?width=80pc&classes=shadow)
+## Deployment Milestones
 
-The Velociraptor server is typically deployed on a cloud VM and runs a number of components as separate threads. The GUI serves the Admin UI - a Web application that can be used to control Velociraptor and orchestrate hunts and collections from the endpoints.
+At a high level, your Velociraptor deployment will consist of 3 tasks: setting up a server, deploying clients, and granting user access to the console.
 
-The endpoints themselves run the **Velociraptor Client** as a
-service. The client is simply the Velociraptor instance running on the
-endpoint.
 
-Clients have a persistent connection with the server. The server is
-therefore able to issue a task to the clients immediately as soon as
-the User scheduled it (Many other solutions rely on periodic polling
-between endpoint and the server leading to latency between issuing a
-new task and receiving the results - not so with Velociraptor).
+| Milestone               | Description                                                                                                                                                                                                                                                                                                                                      |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Task 1: Deploy a Server | Choose the deployment method that works best for you: <br>* Self-Signed SSL - recommended for on-premises environments  <br>* Cloud Deployment - recommended for easy deployments  <br>* Instant Velociraptor - recommended if you want to install Velociraptor as a self-contained client and server on your local machine for testing purposes |
+| Task 2: Deploy Clients  | Deploy clients on your endpoints using one of the recommended methods:<br>* Run clients interactively <br>* Install using Custom MSI <br>* Install the Client as a Service<br>* Agentless Deployment                                                                                                                                             |
+| Task 3: Authorize Users | Grant user access to the Velociraptor console.               
 
-Velociraptor is distributed as a **Single Binary** for ease of
-deployment. The same binary can act as a server, client or a number of
-utility programs depending on command line flags.
+## Typical Deployment 
 
-Velociraptor does not use an external datastore - all data is stored
-within the server's filesystem in regular files and directories making
-backups and data lifecycle management a breeze. Therefore you do not
-need any additional infrastructure such as databases or cloud
-services. Velociraptor is compatible with distributed filesystems such
-as Amazon EFS, Google Filestore or generic NFS.
+Each deployment relies on unique configuration files, which include information such as connection URLs, DNS names, and unique cryptographic keys. Since key material is unique to each deployment, one Velociraptor deployment cannot connect with another deployment.
 
-### Typical Deployment
+The **Velociraptor Server** is typically deployed on a cloud VM and runs a number of components as separate threads. The GUI serves the Admin UI - a Web application that can be used to control Velociraptor and orchestrate hunts and collections from the endpoints.
+The endpoints themselves run the Velociraptor Client as a service. The client is simply the Velociraptor instance running on the endpoint.
+Velociraptor Clients maintain a persistent connection with the server. This allows the server to issue a task to the clients as soon as it is scheduled by the user.  (Many other solutions rely on periodic polling between endpoint and the server leading to latency between issuing a new task and receiving the results - not so with Velociraptor).
 
-By deployment we mean to stand up a new Velociraptor server instance. Typically this consists of a number of broad steps:
+Velociraptor is distributed as a **Single Binary**, which can act as a server, client or a number of utility programs depending on command line flags.
+Velociraptor does not use an external datastore - all data is stored within the server’s filesystem in regular files and directories, making backups and data lifecycle management a breeze. You do not need any additional infrastructure such as databases or cloud services. Velociraptor is compatible with distributed file systems such as Amazon EFS, Google Filestore or generic NFS.
 
-1. Generate a configuration file for the server and clients
-2. Create a server package for deployment which includes the generated configuration file.
-3. Spin up a cloud VM for the server (If deploying in the cloud) or create a new physical server.
-4. Install the server package on the VM - this will bring the GUI and frontends up.
+**A typical deployment includes the following steps:**  
+1. Generate a configuration file for the server and clients.
+2. Create a server package that includes the generated configuration file.
+3. Set up a cloud VM for the server (If deploying in the cloud) or create a new physical server.
+4. Install the server package on the VM. Once installed you will be able to access the  Admin GUI and front end.
 5. Create client packages for target operating systems (e.g. MSI for windows).
-
-Each deployment relies on unique configuration files, which include
-information such as connection URLs, DNS names and unique
-cryptographic keys. The configuration files ensure that one
-Velociraptor deployment can not connect with another deployment since
-key material is unique to each deployment.
 
 {{% notice info %}}
 We typically use Ubuntu or Debian based VMs to deploy the server in
 production. We do not support Windows based servers at scale, although
-it is fine to install the server on windows for a demo or for a few
+you can install the server on windows for a demo or for a few
 endpoints.
 {{% /notice %}}
 
+## Instant Velociraptor
 
-### Resource considerations
-
-The secret behind Velociraptor's scalability lies in the use of VQL to
-query the endpoint. The server does not usually have to do much work:
-All the server does is send a VQL query to the endpoints. The VQL
-query executes on the endpoint and any results from the query (Queries
-always returns rows encoded in JSON) are sent back to the server. The
-server simply needs to write the queries into its filesystem --
-Typically the server does not need to parse or process the responses
-from the endpoint.
-
-Because the server performs minimal processing on the collected data,
-it is able to handle a very high volume of requests simultaneously.
-
-See [Performance Considerations](resources) for a discussion of
-resource sizing and scale related tuning parameters available.
-
-### Instant Velociraptor
-
-If you just want to play with Velociraptor, you do not need to deploy
-a complete server. Simply download the Velociraptor executable for
+If you want to quickly set up a Velociraptor sandbox for evaluation, testing, or another reason, you can install Instant Velociraptor.  It’s a fully functional Velociraptor system that is deployed only to your local machine. Just download the Velociraptor executable for
 your platform from the [GitHub project's releases page](https://github.com/Velocidex/velociraptor/releases)
-and start it with the `gui` command.
+and run the `gui` command.
 
 ```sh
 Velociraptor.exe gui
 ```
+The `gui` command automatically creates new server and client
+configuration files.
 
-The `gui` command automatically creates a new server and client
-configuration files with the server:
-
-* Server only listening on the local loopback interface.
-* Client will connect to the server over the loopback.
-* Datastore directory is set to the user's temp folder.
-* A single administrator user is created with username `admin` and password `password`.
-* A browser is launched with those credentials to connect to the welcome screen.
+* The Server only listens on the local loopback interface.
+* The Client connects to the server over the loopback.
+A data store directory is set to the user’s temp folder.
+A single administrator user is created with username `admin` and `password`.
+A browser is launched with those credentials to connect to the welcome screen.
 
 {{% notice tip %}} By default the `gui` command uses the temp folder
 as it's data store. Most OS's clean the temp folder periodically so if
 you frequently use the same folder you might find missing files. You
 can specify a different data store directory using the `--datastore`
 flag to work with a persistently stored data store.  {{% /notice %}}
-
-### Common deployment scenarios
-
-{{% children %}}
-
-
-#### Self Signed SSL mode
-
-Frontend served using TLS on port 8000 (connected to clients)
-GUI uses basic authentication with usernames/passwords.
-GUI Served over loopback port 8889 (127.0.0.1)
-By default not exposed to the network
-You can use SSH tunneling to forward the GUI
-
-#### Installing a new server
-
-Use the password provided in the Workshop setup to log into the server.
-Fetch the latest Velociraptor Windows and Linux release binaries
-Create a new configuration
-
-```sh
-velociraptor config generate -i
-```
-
-Create a new server debian package
-
-```sh
-velociraptor.exe --config server.config.yaml debian server  --binary velociraptor-v0.5.5-windows.exe
-```
-
-
-#### Installing a new server
-
-Push the debian package to the server using scp
-
-```sh
-scp velociraptor_server*.deb mike@123.45.67.89:/tmp/
-```
-
-Install package
-```sh
-sudo dpkg -i velociraptor_server*.deb
-```
-
-### Automating config generation
-
-Some people want to automate the config generation step.
-Velociraptor supports a JSON merge for non interactive configuration generation
-
-```sh
-velociraptor config generate --merge
-    '{"autocert_domain": "domain.com", "autocert_cert_cache": "/foo/bar"}'
-```
-
-The service adds a new velociraptor user to run under.
-You can now access the Velociraptor server using your browser.
-
-The first time you navigate to the SSL URL the server will obtain a
-certificate from Let's Encrypt. There will be a small pause as this
-happens.
-
-You will be redirected to Google for authentication - Velociraptor
-does not handle any credentials in this configuration. Google will
-determine if the user authenticated properly (2 FA etc) and convey
-simple info like the user’s email address and avatar.

--- a/content/docs/overview/deployment/_index.md
+++ b/content/docs/overview/deployment/_index.md
@@ -34,7 +34,7 @@ Velociraptor does not use an external datastore - all data is stored within the 
 2. Create a server package that includes the generated configuration file.
 3. Set up a cloud VM for the server (If deploying in the cloud) or create a new physical server.
 4. Install the server package on the VM. Once installed you will be able to access the  Admin GUI and front end.
-5. Create client packages for target operating systems (e.g. MSI for windows).
+5. Create client packages for target operating systems (for example, MSI for windows).
 
 {{% notice info %}}
 We typically use Ubuntu or Debian based VMs to deploy the server in


### PR DESCRIPTION
- Updated overview, and edited for grammar and flow 
- Added the deployment milestones table 
- Moved the SSL content to the Self-Signed SSL page
- Removed the diagram (for now...but we can replace it, or perhaps move it to the Velociraptor Overview?)