### PR TITLE
command is logman not logmand

### DIFF
--- a/content/docs/forensic/event_logs/_index.md
+++ b/content/docs/forensic/event_logs/_index.md
@@ -168,7 +168,7 @@ itself as being able to provide ETW events. A Consumer is a routine
 that registers interest in a provider (e.g. Velociraptor is a
 consumer).
 
-You can enumerate all providers on a system using the `logmand query
+You can enumerate all providers on a system using the `logman query
 providers` command which lists all the ETW providers' GUIDs.
 
 ![Enumerating ETW providers](providers.png)


### PR DESCRIPTION
C:\Users\user\Desktop>logmand query providers
'logmand' is not recognized as an internal or external command,
operable program or batch file.

C:\Users\user\Desktop>logman query providers

Provider                                 GUID
-------------------------------------------------------------------------------
ACPI Driver Trace Provider               {DAB01D4D-2D48-477D-B1C3-DAAD0CE6F06B}