### PR TITLE
Update OfficeServerCache.yaml

### DIFF
--- a/content/exchange/artifacts/OfficeServerCache.yaml
+++ b/content/exchange/artifacts/OfficeServerCache.yaml
@@ -14,7 +14,7 @@ type: CLIENT
 
 parameters:
   - name: OfficeServerCacheKey
-    default: SOFTWARE\Microsoft\Office\15.0\Common\Internet\Server Cache\**
+    default: SOFTWARE\Microsoft\Office\*\Common\Internet\Server Cache\**
   - name: UserNameRegex
     default: .
     description: Filter by this UserName regex.


### PR DESCRIPTION
Adding generic Office support. I have 16.0 installed and this artifact was supporting 15.0 only
![image](https://user-images.githubusercontent.com/13081800/132971136-ec5588ac-21f7-47b6-ade9-4c9bf86a4566.png)
