### PR TITLE
Create DetectItEasy (DIEC)

### DIFF
--- a/content/exchange/artifacts/DIEC.yaml
+++ b/content/exchange/artifacts/DIEC.yaml
@@ -1,0 +1,80 @@
+name: Windows.Applications.DIEC
+description: |
+    Execute DetectItEasy (console version) on specified paths and return rows of results
+    to hunt/filter on binaries based types of files (E.g.: Packed binaries and its packers)
+
+author: Eduardo Mattos - @eduardfir
+
+reference:
+  - https://github.com/horsicq/Detect-It-Easy
+
+type: CLIENT
+
+tools:
+  - name: DIEC
+    url: https://github.com/horsicq/DIE-engine/releases/download/3.03b/die_win64_portable_3.03.zip
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: TargetGlob
+    default: C:\Users\**\*.{exe,dll}
+ 
+  - name: EntropyScan
+    type: bool
+
+sources:
+  - query: |
+        -- preparation
+        LET Toolzip <= SELECT FullPath FROM Artifact.Generic.Utils.FetchBinary(ToolName="DIEC", IsExecutable=FALSE)
+        LET TmpDir <= tempdir(remove_last=TRUE)
+        LET UnzipIt <= SELECT * FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
+        
+        LET Targets <= SELECT FullPath FROM glob(globs=TargetGlob)
+        
+        -- execute DIEC
+        LET ExecDIEC <= SELECT * FROM if(condition=EntropyScan,
+                        then={ -- execute EntropyScan
+                            SELECT * FROM foreach(row=Targets,
+                                query={ 
+                                    SELECT parse_json(data=Stdout) as DiecOutput, FullPath 
+                                    FROM execve(argv=[
+                                        TmpDir + "/die_win64_portable/diec.exe", 
+                                        "-e",
+                                        "-j",
+                                        FullPath])
+                                })
+                        },
+                        else={ -- execute DeepScan
+                            SELECT * FROM foreach(row=Targets,
+                                query={ 
+                                    SELECT parse_json(data=Stdout) as DiecOutput, FullPath 
+                                    FROM execve(argv=[
+                                        TmpDir + "/die_win64_portable/diec.exe", 
+                                        "-d",
+                                        "-j",
+                                        FullPath])
+                                })
+                        })
+                        
+        -- format the output according to selected scan type
+        SELECT * FROM if(condition=EntropyScan,
+            then={
+                SELECT 
+                    DiecOutput.records as Records, 
+                    DiecOutput.status as Status,
+                    DiecOutput.total as Entropy,
+                    FullPath
+                FROM ExecDIEC
+            },
+            else={
+                SELECT 
+                    dict(Arch=DiecOutput.arch, 
+                    Endianess=DiecOutput.endianess,
+                    FileType=DiecOutput.filetype,
+                    Mode=DiecOutput.mode,
+                    Type=DiecOutput.type) as PEInfo,
+                    DiecOutput.detects as Detects,
+                    FullPath
+                FROM ExecDIEC
+            })


### PR DESCRIPTION
Execute DetectItEasy (console version) on specified paths and return rows of results to hunt/filter on binaries based types of files (E.g.: Packed binaries and its packers)