### PR TITLE
Create Windows.Detection.ChinaChopper.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Detection.ChinaChopper.yaml
+++ b/content/exchange/artifacts/Windows.Detection.ChinaChopper.yaml
@@ -1,0 +1,35 @@
+name: Windows.Detection.ChinaChopper
+description: |
+  This artifact hunts for CVE-2021-27065 (Microsoft Exchange ProxyLogon RCE)
+  exploitation by parsing entries in the 'MSExchange Management.evtx' log.
+
+  This log file is unique to Exchange and can be useful when ECP logs are
+  no longer available. Webshell detection syntax is specific to 'China Chopper'
+  via the PowerShell 'Set-OabVirtualDirectory' cmdlet.
+
+author: Deepak Sharma - @rxurien
+
+type: CLIENT
+
+reference:
+  - https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities/
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: LogFile
+    default: C:/Windows/System32/Winevt/Logs/MSExchange Management.evtx
+
+sources:
+  - queries:
+      - SELECT timestamp(epoch=int(int=System.TimeCreated.SystemTime)) as CreationTime,
+            System.Channel as Channel,
+            System.EventID.Value as EventID,
+            Message,
+            EventData.Data[0] as Cmdlet,
+            EventData.Data[1] as Payload,
+            EventData
+               
+        FROM parse_evtx(filename=LogFile)
+
+        WHERE (Message =~ "set-oabvirtualdirectory" and Message =~ "script") or (Cmdlet =~ "set-oabvirtualdirectory" and Payload =~ "script")


### PR DESCRIPTION
This artifact hunts for CVE-2021-27065 (Microsoft Exchange ProxyLogon RCE) exploitation by parsing entries in the 'MSExchange Management.evtx' log.

This log file is unique to Exchange and can be useful when ECP logs are no longer available. Webshell detection syntax is specific to 'China Chopper' via the PowerShell 'Set-OabVirtualDirectory' cmdlet.

Reference: https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities/
Sample: https://raw.githubusercontent.com/Seeps/Velociraptor-Artifacts/main/samples/chinachopper.PNG