### PR TITLE
Fix footer typo

### DIFF
--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -1,4 +1,4 @@
-<div class="footer-copyright">Brough to you by
+<div class="footer-copyright">Brought to you by
   <img src="/images/Rapid7_logo.svg" class="rapid7">
   <br> <i class="fas fa-copyright"></i> 2021
 </div>


### PR DESCRIPTION
Fixes a small typo in the footer

#### Before

![image](https://user-images.githubusercontent.com/1271782/141687873-d1b09d68-1dbd-4c60-9dab-318a55e67de0.png)

#### After

![image](https://user-images.githubusercontent.com/1271782/141687866-178fd7c3-b78f-4659-9946-828d8e849ac4.png)
