### PR TITLE
Create Emotet Carver Artifact

### DIFF
--- a/content/exchange/artifacts/Windows.Carving.Emotet.yaml
+++ b/content/exchange/artifacts/Windows.Carving.Emotet.yaml
@@ -1,0 +1,145 @@
+name: Windows.Carving.Emotet
+author: "Eduardo Mattos - @eduardfir"
+description: |
+    This artifact yara-scans memory or unpacked DLL samples for the new 2021 Emotet
+    detections, decrypts and returns the C2 list.
+    
+    You may select specific file paths or processes to be yara-scanned, or allow 
+    it to yara-scan all memory space.
+    
+    Currently this artifact parses encrypted configurations from the Emotet variants
+    introducted in November 2021. It will not parse the configurations from earlier 
+    variants.
+    
+    NOTE:
+    This content simply carves the configuration and does not unpack files on disk. 
+    That means pointing this artifact as a packed or obfuscated file will not obtain the expected results.
+type: CLIENT
+
+reference:
+  - https://github.com/kevoreilly/CAPEv2/blob/master/modules/processing/parsers/mwcp/Emotet.py
+  - https://github.com/OALabs/Lab-Notes/blob/main/Emotet/Emotet.ipynb
+
+parameters:
+  - name: TargetFileGlob
+    default:
+  - name: PidRegex
+    default: .
+  - name: ProcessRegex
+    default: .
+  - name: DetectionYara
+    default: |
+        rule Emotet {
+            meta:
+                author = "Eduardo Mattos"
+                description = "Emotet Payload"
+            strings:
+                $snippetD = {8D 44 [2] 50 68 [4] FF 74 [2] FF 74 [2] 8B 54 [2] 8B 4C [2] E8 [4] 8B 54 [2] 83 C4 10 89 44 [2] 8B F8 03 44 [2] B9 [4] 89 44 [2] E9 [2] FF FF}
+                $snippetE = {68 [4] FF 74 [2] 8B 4C [2] E8 [4] 8B 54 [2] 83 C4 10 89 44 [2] 8B F8 03 44 [2] B9 [4] 89 44 [2] E9 [2] FF FF}
+            condition:
+                any of them
+        }
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+        -- find target files
+        LET targetFiles = SELECT FullPath FROM glob(globs=TargetFileGlob) 
+                
+        -- find velociraptor process
+        LET me <= SELECT Pid 
+                  FROM pslist(pid=getpid())
+        
+        -- find all processes and add filters
+        LET processes <= SELECT Name AS ProcessName, CommandLine, Pid
+                        FROM pslist()
+                        WHERE Name =~ ProcessRegex 
+                            AND format(format="%d", args=Pid) =~ PidRegex
+                            AND NOT Pid in me.Pid
+        -- scan processes in scope with our DetectionYara
+        LET processDetections <= SELECT * FROM foreach(row=processes,
+                                query={
+                                    SELECT * FROM if(condition=TargetFileGlob="",
+                                        then={
+                                            SELECT *, ProcessName, CommandLine, Pid, Rule AS YaraRule
+                                            FROM proc_yara(pid=Pid, rules=DetectionYara)
+                                        })
+                                })
+        -- scan files in scope with our DetectionYara
+        LET fileDetections = SELECT * FROM foreach(row=targetFiles,
+                                query={
+                                    SELECT * FROM if(condition=TargetFileGlob,
+                                        then={
+                                            SELECT * FROM switch(
+                                                a={ -- yara detection
+                                                    SELECT FullPath, Rule AS YaraRule
+                                                    FROM yara(files=FullPath, rules=DetectionYara)
+                                                },
+                                                b={ -- yara miss
+                                                    SELECT FullPath, Null AS YaraRule 
+                                                    FROM targetFiles
+                                                })
+                                        },
+                                        else={ -- no yara detection run
+                                            SELECT FullPath, 'N/A' AS YaraRule 
+                                            FROM targetFiles
+                                        })
+                             })
+        -- return the VAD region size from yara detections for later use                         
+        LET regionDetections = SELECT * 
+                                FROM foreach(row=processDetections,
+                                    query={
+                                        SELECT YaraRule, Pid, ProcessName, CommandLine, Address as EmotetBaseOffset, Size AS VADSize
+                                        FROM vad(pid=Pid)
+                                        WHERE Protection =~ "xrw"
+                                })
+        
+        -- get data from the whole PE
+        LET peData <= SELECT * FROM if(condition=TargetFileGlob,
+                                        then={ -- query files
+                                            SELECT YaraRule, FullPath,
+                                                read_file(filename=FullPath) AS PEData
+                                            FROM fileDetections
+                                        },
+                                        else={ -- query processes
+                                            SELECT YaraRule, Pid, ProcessName, CommandLine,
+                                                read_file(filename=str(str=Pid), accessor='process', offset=EmotetBaseOffset, length=VADSize) AS PEData
+                                            FROM regionDetections
+                                        })
+                                        
+        -- return .data section info
+        LET sectionInfo <= SELECT *,
+                                parse_pe(file=PEData, accessor="data").Sections[2] AS DataSections
+                           FROM peData
+                           
+        -- read the data from .data sections
+        LET sectionData <= SELECT *,
+                                read_file(filename=PEData, accessor="data", offset=DataSections.RVA, length=DataSections.Size) AS EmotetDataSectionData
+                           FROM sectionInfo
+
+        -- parse the .data sections to extract the C2 config
+        LET parsedDataSection = SELECT *,
+                            parse_binary(filename=EmotetDataSectionData, accessor="data", profile='''[
+                                ["EmotetC2Config", 0, [
+                                        ["Key4Size", 0, "String", {"length": 1, "term":""}],
+                                        ["Key", 0, "String", {"length": 4, "term":""}],
+                                        ["SizeEncoded", 4, "String", {"length": 1, "term":""}],
+                                        ["C2List", 8, "String", {"length":"x=> parse_binary(accessor='data',filename=xor(string=x.SizeEncoded, key=x.Key4Size),struct='uint8')", "term":""}]
+                                    ]
+                                ]
+                            ]''', struct="EmotetC2Config") AS EmotetEncodedC2Conf
+                          FROM sectionData  
+
+        -- format the decrypted configurations
+        SELECT * FROM if(condition=TargetFileGlob,
+            then= {
+                SELECT YaraRule, FullPath,
+                    { SELECT ip(netaddr4_be=int(int="0x" + IPAdd)) AS IPAddress, int(int="0x" + Port) AS PortNum FROM parse_records_with_regex(file=format(format="%x", args=xor(string=EmotetEncodedC2Conf.C2List, key=EmotetEncodedC2Conf.Key)), accessor="data", regex='(?P<IPAdd>........)(?P<Port>....)....')} AS C2Info
+                FROM parsedDataSection
+            },
+            else= {
+                SELECT YaraRule, Pid, ProcessName, CommandLine,
+                    { SELECT ip(netaddr4_be=int(int="0x" + IPAdd)) AS IPAddress, int(int="0x" + Port) AS PortNum FROM parse_records_with_regex(file=format(format="%x", args=xor(string=EmotetEncodedC2Conf.C2List, key=EmotetEncodedC2Conf.Key)), accessor="data", regex='(?P<IPAdd>........)(?P<Port>....)....')} AS C2Info
+                FROM parsedDataSection
+        })


### PR DESCRIPTION
    This artifact yara-scans memory or unpacked DLL samples for the new 2021 Emotet
    detections, decrypts and returns the C2 list.
    
    You may select specific file paths or processes to be yara-scanned, or allow 
    it to yara-scan all memory space.
    
    Currently this artifact parses encrypted configurations from the Emotet variants
    introducted in November 2021. It will not parse the configurations from earlier 
    variants.
    
    NOTE:
    This content simply carves the configuration and does not unpack files on disk. 
    That means pointing this artifact as a packed or obfuscated file will not obtain the expected results.