### PR TITLE
Update log4jRCE.yaml

### DIFF
--- a/content/exchange/artifacts/log4jRCE.yaml
+++ b/content/exchange/artifacts/log4jRCE.yaml
@@ -299,7 +299,9 @@ sources:
                     Rule, Tags, Meta,
                     str(str=String.Data) AS HitContext,
                     String.Offset AS HitOffset
-                FROM yara(rules=yara.Content[0],files=FullPath,accessor='gzip')
+                FROM switch(
+                    a={ SELECT * FROM yara(rules=yara.Content[0],files=FullPath, accessor='gzip') },
+                    b={ SELECT * FROM yara(rules=yara.Content[0],files=FullPath) })
                 LIMIT 1
             })
       


### PR DESCRIPTION
Add temp fix to fix an accessor bug on windows.
Linux enables scanning non gzip files from the gzip accessor, windows appears to not.