### PR TITLE
Update log4jRCE.yaml

### DIFF
--- a/content/exchange/artifacts/log4jRCE.yaml
+++ b/content/exchange/artifacts/log4jRCE.yaml
@@ -293,15 +293,13 @@ sources:
       LET hits = SELECT * FROM foreach(row=files,
             query={
                 SELECT
-                    FileName as FullPath,
+                    url(parse=FileName).Path as FullPath,
                     Size,
                     Mtime, Atime, Ctime, Btime,
                     Rule, Tags, Meta,
                     str(str=String.Data) AS HitContext,
                     String.Offset AS HitOffset
-                FROM switch(
-                    a={ SELECT * FROM yara(rules=yara.Content[0],files=FullPath, accessor='gzip') },
-                    b={ SELECT * FROM yara(rules=yara.Content[0],files=FullPath) })
+                FROM yara(rules=yara.Content[0],files=url(path=FullPath, scheme="file"), accessor='gzip')
                 LIMIT 1
             })
       


### PR DESCRIPTION
add FilePath formatting fix that was causing an issue in Windows with yara gzip accessor.