### PR TITLE
Create Custom.Generic.Detection.LunasecLog4shell.yaml

### DIFF
--- a/content/exchange/artifacts/Custom.Generic.Detection.LunasecLog4shell.yaml
+++ b/content/exchange/artifacts/Custom.Generic.Detection.LunasecLog4shell.yaml
@@ -1,0 +1,47 @@
+name: Custom.Generic.Detection.LunasecLog4shell
+author: "Marinus Boekelo & Noël Keijzer - Northwave CERT"
+description: |
+  Uses the Log4Shell scanner of Lunasec to scan the file systems of all drives of the host for any sign of vulnerabilities related to Log4shell
+
+tools:
+  - name: log4shell_linux_amd64
+    url: https://github.com/lunasec-io/lunasec/releases/download/v1.1.2-log4shell/log4shell_1.1.2-log4shell_Linux_x86_64
+    serve_locally: true
+
+  - name: log4shell_linux_x86
+    url: https://github.com/lunasec-io/lunasec/releases/download/v1.1.2-log4shell/log4shell_1.1.2-log4shell_Linux_i386
+    serve_locally: true
+
+  - name: log4shell_windows_amd64
+    url: https://github.com/lunasec-io/lunasec/releases/download/v1.1.2-log4shell/log4shell_1.1.2-log4shell_Windows_x86_64.exe
+    serve_locally: true
+
+  - name: log4shell_windows_x86
+    url: https://github.com/lunasec-io/lunasec/releases/download/v1.1.2-log4shell/log4shell_1.1.2-log4shell_Windows_i386.exe
+    serve_locally: true
+
+reference:
+  - https://github.com/lunasec-io/lunasec/releases/
+
+precondition: SELECT OS From info() where OS = "windows" or OS = "linux"
+
+required_permissions:
+  - EXECVE
+
+parameters:
+  - name: ToolInfo
+    description: Override Tool information.
+
+sources:
+  - query: |
+      LET os_info <= SELECT Architecture, OS FROM info()
+      // Get the path to the binary.
+      LET bin <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(
+              ToolName= "log4shell_" + os_info[0].OS + "_" + os_info[0].Architecture,
+              ToolInfo=ToolInfo)
+      
+      // Select the Disks to scan
+      LET disks = if(condition=(os_info[0].OS="windows"), then= { SELECT Mountpoint + "\\\\" as Mountpoint FROM filesystems()}, else={ SELECT "/" as Mountpoint FROM scope() })
+      // Scan every disk
+      LET results = SELECT * FROM foreach(row=disks, query={ SELECT parse_json(data=Stdout) AS record FROM execve(argv=[bin[0].FullPath,"scan","--json",Mountpoint], sep="\n") })
+      SELECT * FROM foreach(row= results, query={ SELECT * FROM record })


### PR DESCRIPTION
Artifact that uses the Log4Shell scanner of Lunasec to scan the file systems of all drives of the host for any sign of vulnerabilities related to Log4shell. Added because this scanner is able to scan nested jar files (which the existing artifacts don't do).