### PR TITLE
Syntax error with placement of --use_sysv

### DIFF
--- a/content/docs/deployment/clients/_index.md
+++ b/content/docs/deployment/clients/_index.md
@@ -212,9 +212,9 @@ Create (Most OS variants with systemctl)
 ```shell
 # velociraptor-vx.x.x-linux-amd64 --config client.config.yaml rpm client
 ```
-Create (OS variants without systemctl and old GLIBC)
+Create (OS variants without systemctl and old GLIBC i.e. CentOS6)
 ```shell
-# velociraptor-vx.x.x-linux-amd64-centos --config --use_sysv client.config.yaml rpm client
+# velociraptor-vx.x.x-linux-amd64-centos --config client.config.yaml rpm client --use_sysv
 ```
 Install
 ```shell


### PR DESCRIPTION
--use_sysv should be at the end, not between --config and the config file name.
Added i.e. CentOS6 as the main variant this syntax should be used with.