### PR TITLE
Create Windows.Applications.AnyDesk.LogParser

### DIFF
--- a/content/exchange/artifacts/Windows.Applications.AnyDesk.LogParser
+++ b/content/exchange/artifacts/Windows.Applications.AnyDesk.LogParser
@@ -1,0 +1,36 @@
+name: Windows.Applications.AnyDesk.LogParser
+description: |
+   Parses the AnyDesk ad.trace log file.
+
+   Info such as connection times, clipboard activity, and remote host information are captured.
+
+author: Rob Homewood 
+
+type: CLIENT
+parameters:
+    - name: FileGlob
+      default: C:\Users\*\AppData\Roaming\Anydesk\ad.trace
+
+sources:
+    - query: |
+
+        -- Grabs file path of provided file glob
+        LET InputLogPath <= SELECT FullPath 
+        FROM glob(globs=FileGlob)
+
+        -- Parses file against regex
+        LET parse_log <= SELECT
+            parse_string_with_regex(
+                string=Line,
+                regex= ['''\s+(?P<Info>(info)\s+)''', 
+                       '''(?P<Date>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2})''',
+                       '''(\d{4,}.*?)(?P<PPID>\b\d{4,5}\b)''',
+                       '''\b\b\d{4,5}.*(?P<PID>\b\b\d{4,5}\b)''',
+                       '''(?P<Message>(anynet.relay_conn|anynet.any_socket|app.local_file_transfer|app.prepare_task|app.local_file_transfer|app.ctrl_clip_comp|app.backend_session|app.ft_src_session|app.ctrl_clip_comp)\s-\s\w.*)'''])
+                       as Record
+                       FROM parse_lines(filename=InputLogPath.FullPath)
+                    
+        -- Prints matching data where there is an entry in Record.Message                    
+        SELECT Record.Date as Date, Record.PPID as PPID, Record.PID as PID, Record.Message as Message 
+        FROM parse_log 
+        WHERE Record.Message


### PR DESCRIPTION
Collects info from AnyDesk's ad.trace file located within AppData. Attempts to pull useful information such as connection times, clipboard activity, and information about the remote host.