### PR TITLE
Create HiddenUsers.yaml

### DIFF
--- a/content/exchange/artifacts/HiddenUsers.yaml
+++ b/content/exchange/artifacts/HiddenUsers.yaml
@@ -1,0 +1,42 @@
+name: Windows.Registry.HiddenUsers
+description: |
+    Find hidden user accounts through registry values on the filesystem.
+
+    In Windows, adversaries may hide user accounts via settings in the Registry. 
+    For example, an adversary may add a value to the Windows Registry 
+    (via Reg or other means) that will hide the user "test" from 
+    the Windows login screen: 
+    
+    reg.exe ADD 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccountsUserList' /v test /t REG_DWORD /d 0 /f.
+
+    * ATT&CK tactic: Defense Evasion, Hide Artifacts: Hidden Users
+    * ATT&CK technique: T1564.002
+
+reference:
+  - https://attack.mitre.org/techniques/T1564/002/
+  - https://github.com/Res260/conti_202202_leak_procedures/blob/main/12_using_anydesk.txt
+  
+type: CLIENT
+
+author: Eduardo Mattos - @eduardfir
+
+precondition:
+  SELECT * FROM info() where OS = 'windows'
+
+parameters:
+  - name: SearchRegistryGlob
+    default: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\Userlist\**
+    description: Use a glob to define the keys that will be searched.
+
+sources:
+  - query: |
+        SELECT  Name,
+                FullPath,
+                Data,
+                Sys,
+                ModTime as Modified
+        FROM glob(globs=SearchRegistryGlob, accessor='registry')
+
+column_types:
+  - name: Modified
+    type: timestamp


### PR DESCRIPTION
    Find hidden user accounts through registry values on the filesystem.

    In Windows, adversaries may hide user accounts via settings in the Registry. 
    For example, an adversary may add a value to the Windows Registry 
    (via Reg or other means) that will hide the user "test" from 
    the Windows login screen: 
    
    reg.exe ADD 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccountsUserList' /v test /t REG_DWORD /d 0 /f.

    * ATT&CK tactic: Defense Evasion, Hide Artifacts: Hidden Users
    * ATT&CK technique: T1564.002

References:
- https://attack.mitre.org/techniques/T1564/002/
-  https://github.com/Res260/conti_202202_leak_procedures/blob/main/12_using_anydesk.txt