### PR TITLE
Create PowerEfficiencyDiagnostics.yaml

### DIFF
--- a/content/exchange/artifacts/PowerEfficiencyDiagnostics.yaml
+++ b/content/exchange/artifacts/PowerEfficiencyDiagnostics.yaml
@@ -1,0 +1,50 @@
+name: Windows.System.PowerEfficiencyDiagnostics
+author: "Eduardo Mattos - @eduardfir"
+description: |
+  This artifact parses the XML Energy Reports from the Power Efficiency 
+  Diagnostics feature of Windows, returning the processes which had high 
+  CPU usage, including which 
+  
+  Some tools utilized by threat actors will generate high CPU usage and so 
+  are recorded in these reports.
+
+reference:
+  - https://twitter.com/rj_chap/status/1502354627903123458
+  
+parameters:
+  - name: TargetGlob
+    default: C:\ProgramData\Microsoft\Windows\Power Efficiency Diagnostics\*.xml
+
+sources:
+  - query: |
+        -- select XML reports
+        LET Targets <= SELECT FullPath, Mtime as FileMtime FROM glob(globs=TargetGlob)
+
+        -- parse XML reports and return specific CPU Usage entries
+        LET SigProcUtil <= SELECT 
+                            parse_xml(file=FullPath).EnergyReport.Troubleshooter[5].AnalysisLog.LogEntry.Details.Detail as LogDetail,
+                            FullPath,
+                            FileMtime
+                           FROM Targets
+        
+        -- iterate through nested entries and return relevant fields
+        SELECT 
+            { SELECT get(item=_value, field="Value") as Value from foreach(row=LogDetailEntry) 
+                WHERE _value.Name = "Process Name"
+            } as ProcessName, 
+            { SELECT get(item=_value, field="Value") as Value from foreach(row=LogDetailEntry) 
+                WHERE _value.Name = "PID"
+            } as PID,
+            { SELECT get(item=_value, field="Value") as Value from foreach(row=LogDetailEntry) 
+                WHERE _value.Name = "Average Utilization (%)"
+            } as AvgUtilization,
+            { SELECT get(item=_value, field="Value") as Value from foreach(row=LogDetailEntry) 
+                WHERE _value.Name = "Module"
+            } as Modules,
+            FullPath,
+            FileMtime
+        FROM foreach(row=SigProcUtil, 
+            query= {
+                SELECT _value as LogDetailEntry, FullPath, FileMtime FROM foreach(row=SigProcUtil[0].LogDetail) 
+            })
+        WHERE ProcessName


### PR DESCRIPTION
This artifact parses the XML Energy Reports from the Power Efficiency Diagnostics feature of Windows, returning the processes which had high CPU usage, as well as its PID and modules utilized by it which had higher impact on the CPU.

Some tools utilized by threat actors will generate high CPU usage and so are recorded in these reports.