### PR TITLE
Create Windows.Carving.IcedID.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Carving.IcedID.yaml
+++ b/content/exchange/artifacts/Windows.Carving.IcedID.yaml
@@ -1,0 +1,183 @@
+name: Windows.Carving.IcedID
+author: "Eduardo Mattos - @eduardfir"
+description: |
+    This artifact yara-scans memory or unpacked DLL samples for IcedID trojan (also
+    known as BokBot, or Anubis) detections, finds, decodes and returns the 
+    Campaign ID and C2 configurations.
+
+    You may select specific file paths or processes to be
+    yara-scanned, or allow it to yara-scan all memory space.
+
+    NOTE: This content simply carves the configuration and does not
+    unpack files on disk.  That means pointing this artifact as a
+    packed or obfuscated file will not obtain the expected results.
+
+type: CLIENT
+
+reference:
+  - https://eln0ty.github.io/malware%20analysis/IcedID/?s=09#decrypt-config
+  - https://github.com/kevoreilly/CAPEv2/blob/b167c22190ab6acf0f788865f9dd4c5c64d73f99/data/yara/CAPE/IcedIDLoader.yar
+  
+parameters:
+  - name: TargetFileGlob
+    default:
+  - name: PidRegex
+    default: .
+  - name: ProcessRegex
+    default: .
+  - name: DetectionYara
+    default: |
+        rule IcedIDLoader {
+            meta:
+                author = "kevoreilly, threathive, enzo"
+                description = "IcedID Loader"
+                cape_type = "IcedID Loader"
+            strings:
+                $crypt1 = {8A 04 ?? D1 C? F7 D? D1 C? 81 E? 20 01 00 00 D1 C? F7 D? 81 E? 01 91 00 00 32 C? 88}
+                $crypt2 = {8B 44 24 04 D1 C8 F7 D0 D1 C8 2D 20 01 00 00 D1 C0 F7 D0 2D 01 91 00 00 C3}
+                $crypt3 = {41 00 8B C8 C1 E1 08 0F B6 C4 66 33 C8 66 89 4? 24 A1 ?? ?? 41 00 89 4? 20 A0 ?? ?? 41 00 D0 E8 32 4? 32}
+                $crypt4 = {0F B6 C8 [0-3] 8B C1 83 E1 0F [0-1] C1 E8 04 [0-1] 0F BE [2-5] 66 [0-1] 89 04 [1-2] 0F BE [2-5] 66 [0-1] 89 44 [2-3] 83 [4-5] 84 C0 75}
+                $crypt5 = {48 C1 E8 ?? 0F BE 44 05 ?? 66 89 04 5E 44 88 75 ?? C7 45 [5] C7 45 [5] C7 45 [5] C7 45 [5] 44 89 5D}
+                $download1 = {8D 44 24 40 50 8D 84 24 44 03 00 00 68 04 21 40 00 50 FF D5 8D 84 24 4C 01 00 00 C7 44 24 28 01 00 00 00 89 44 24 1C 8D 4C 24 1C 8D 84 24 4C 03 00 00 83 C4 0C 89 44 24 14 8B D3 B8 BB 01 00 00 66 89 44 24 18 57}
+                $download2 = {8B 75 ?? 8D 4D ?? 8B 7D ?? 8B D6 57 89 1E 89 1F E8 [4] 59 3D C8 00 00 00 75 05 33 C0 40 EB}
+                $download3 = {B8 50 00 00 00 66 89 45 ?? 4C 89 65 ?? 4C 89 75 ?? E8 [4] 48 8B 1E 3D 94 01 00 00}
+                $major_ver = {0F B6 05 ?? ?? ?? ?? 6A ?? 6A 72 FF 75 0C 6A 70 50 FF 35 ?? ?? ?? ?? 8D 45 80 FF 35 ?? ?? ?? ?? 6A 63 FF 75 08 6A 67 50 FF 75 10 FF 15 ?? ?? ?? ?? 83 C4 38 8B E5 5D C3}
+                $decode = {4? 8D [5-6] 8A 4? [1-3] 32 }//0? 01 88 44 [2] 4?}
+            condition:
+                2 of them
+        }
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+        -- find target files
+        LET targetFiles = SELECT FullPath FROM glob(globs=TargetFileGlob)
+
+        -- find velociraptor process
+        LET me <= SELECT Pid
+                  FROM pslist(pid=getpid())
+
+        -- find all processes and add filters
+        LET processes <= SELECT Name AS ProcessName, CommandLine, Pid
+                        FROM pslist()
+                        WHERE Name =~ ProcessRegex
+                            AND format(format="%d", args=Pid) =~ PidRegex
+                            AND NOT Pid in me.Pid
+                            
+        -- scan processes in scope with our DetectionYara
+        LET processDetections <= SELECT * FROM foreach(row=processes,
+                                query={
+                                    SELECT * FROM if(condition=TargetFileGlob="",
+                                        then={
+                                            SELECT *, ProcessName, CommandLine, Pid, Rule AS YaraRule
+                                            FROM proc_yara(pid=Pid, rules=DetectionYara)
+                                        })
+                                })
+                                
+        -- scan files in scope with our DetectionYara
+        LET fileDetections = SELECT * FROM foreach(row=targetFiles,
+                                query={
+                                    SELECT * FROM if(condition=TargetFileGlob,
+                                        then= {
+                                                SELECT FullPath, Rule AS YaraRule
+                                                FROM yara(files=FullPath, rules=DetectionYara)
+                                        },
+                                        else={ -- no yara detection run
+                                            SELECT FullPath, 'N/A' AS YaraRule
+                                            FROM targetFiles
+                                        })
+                             })
+                 
+        -- return the VAD region size from yara detections for later use
+        LET regionDetections = SELECT *
+                                FROM foreach(row=processDetections,
+                                    query={
+                                        SELECT YaraRule, Pid, ProcessName, CommandLine, Address as IcedIDBaseOffset, Size AS VADSize
+                                        FROM vad(pid=Pid)
+                                        WHERE Protection =~ "xrw"
+                                })
+
+        -- get data from the whole PE
+        LET peData <= SELECT * FROM if(condition=TargetFileGlob,
+                                        then={ -- query files
+                                            SELECT YaraRule, FullPath,
+                                                read_file(filename=FullPath) AS PEData
+                                            FROM fileDetections
+                                        },
+                                        else={ -- query processes
+                                            SELECT YaraRule, Pid, ProcessName, CommandLine,
+                                                read_file(filename=str(str=Pid), accessor='process', offset=IcedIDBaseOffset, length=VADSize) AS PEData
+                                            FROM regionDetections
+                                        })
+
+        -- return .d section info
+        LET sectionInfo <=  SELECT *
+                            FROM foreach(row=peData,
+                                query= { 
+                                    SELECT YaraRule, 
+                                        IcedIDSectionInfo, 
+                                        PEData, 
+                                        FullPath,
+                                        Pid, 
+                                        ProcessName, 
+                                        CommandLine
+                                    FROM foreach(row=parse_pe(file=PEData, accessor="data").Sections,
+                                        query = {
+                                            SELECT _value as IcedIDSectionInfo, 
+                                                FullPath, 
+                                                YaraRule, 
+                                                PEData,
+                                                Pid, 
+                                                ProcessName, 
+                                                CommandLine
+                                            FROM scope()
+                                            WHERE IcedIDSectionInfo.Name = ".d"
+                                         })
+                                    
+                                })
+        
+        -- read the data from .d sections
+        LET sectionData <=  SELECT * FROM if(condition=TargetFileGlob,
+                                        then={ -- query files
+                                            SELECT *,
+                                                read_file(filename=PEData, accessor="data", offset=IcedIDSectionInfo.FileOffset, length=IcedIDSectionInfo.Size) AS IcedIDDSectionData
+                                           FROM sectionInfo
+                                        },
+                                        else={ -- query processes
+                                            SELECT *,
+                                                read_file(filename=PEData, accessor="data", offset=IcedIDSectionInfo.RVA, length=IcedIDSectionInfo.Size) AS IcedIDDSectionData
+                                           FROM sectionInfo
+                                        })
+
+        -- parse the .data sections to extract the C2 config
+        LET parsedDSection = SELECT *,
+                            parse_binary(filename=IcedIDDSectionData, accessor="data", profile='''[
+                                ["IcedIDConfigStruct", 0, [
+                                        ["Key", 0, "String", {"length": 32, "term":""}],
+                                        ["Data", 64, "String", {"length": 32, "term":""}],
+                                        ["DecodedConfig", 0, "Value", {value: "x=> xor(string=x.Data, key=x.Key)"}]
+                                    ]
+                                ]
+                            ]''', struct="IcedIDConfigStruct") AS IcedIDConfig
+                          FROM sectionData
+                          
+        LET formattedConfig <= SELECT *, 
+                                parse_string_with_regex(string=format(format="%X", args=IcedIDConfig.DecodedConfig), regex='(?P<CampaignID>........)(?P<C2>.+)00') as DecodedConfig 
+                               FROM parsedDSection
+
+        -- format the decoded configurations
+        SELECT * FROM if(condition=TargetFileGlob,
+            then= {
+                SELECT YaraRule, FullPath,
+                    parse_binary(accessor='data',filename=unhex(string=DecodedConfig.CampaignID),struct='uint32') as CampaignID,
+                    unhex(string=DecodedConfig.C2) as C2Address
+                FROM formattedConfig
+            },
+            else= {
+                SELECT YaraRule, Pid, ProcessName, CommandLine,
+                    parse_binary(accessor='data',filename=unhex(string=DecodedConfig.CampaignID),struct='uint32') as CampaignID,
+                    unhex(string=DecodedConfig.C2) as C2Address
+                FROM formattedConfig
+                GROUP BY Pid
+        })


### PR DESCRIPTION
This artifact yara-scans memory or unpacked DLL samples for IcedID trojan (also known as BokBot, or Anubis) detections, finds, decodes and returns the Campaign ID and C2 configurations.

You may select specific file paths or processes to be yara-scanned, or allow it to yara-scan all memory space.

NOTE: This content simply carves the configuration and does not unpack files on disk. That means pointing this artifact as a packed or obfuscated file will not obtain the expected results.