### PR TITLE
Create Windows.Applications.DefenderHistory.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Applications.DefenderHistory.yaml
+++ b/content/exchange/artifacts/Windows.Applications.DefenderHistory.yaml
@@ -78,6 +78,7 @@ sources:
                   Size,    
                   parse_binary(filename=FullPath, profile = profile, struct = 'Info') as parsedfile 
             FROM glob(globs = TargetGlob)
+            Where IsDir = False
             
             SELECT  parsedfile.Time as EventTime,
                     parsedfile.ThreatType as ThreatType,

--- a/content/exchange/artifacts/Windows.Applications.DefenderHistory.yaml
+++ b/content/exchange/artifacts/Windows.Applications.DefenderHistory.yaml
@@ -1,0 +1,92 @@
+name: Windows.Applications.DefenderHistory
+author: "Roman Makuch - @rmakuch Kanstantsin Ilioukevitch - @kostyailiouk"
+description:  |
+    This artifact parses the Windows Defender files generated on threat detection and returns
+    the contained parameters created by Windows Defender about the detected threat. 
+
+    By default with no parameters DefenderHistory parses 
+    "C:/ProgramData/Microsoft/Windows Defender/Scans/History/Service/DetectionHistory/**"
+    A different TargetGlob can be entered.
+
+    Based on the research work done by Jordan Klepser @JordanKlepser
+    https://github.com/jklepsercyber/defender-detectionhistory-parser 
+
+reference:
+  - https://github.com/jklepsercyber/defender-detectionhistory-parser
+
+parameters: 
+  - name: TargetGlob
+    description: Glob to target.
+    default: C:/ProgramData/Microsoft/Windows Defender/Scans/History/Service/DetectionHistory/**
+
+sources:
+  - query: |
+        Let profile = '''
+          [
+            ["Info", 0, [
+                ["__FileHeaderSearch", 0, "String", {"length": 6, "term":""}],
+                ["__FileHeader", 0, "Value", {"value":"x=>format(format='%#x', args=x.__FileHeaderSearch)"}],
+                ["__GUID", 24, "GUIDStruct"],
+                ["__MagicVersion", 48, "String", {"length": 38, "encoding":"utf16"}],
+                ["__ThreatTypeLength", 88, "uint8"],
+                ["ThreatType", 96, "String", {"length":"x=> x.__ThreatTypeLength - 2", "encoding":"utf16"}],
+                ["ThreatStatusID", 240, "Enumeration", {
+                    type: "uint8",
+                    map: {
+                         "Unknown": 0,
+                         "Detected": 1,
+                         "Cleaned": 2,
+                         "Quarantined": 3,
+                         "Removed": 4,
+                         "Allowed": 5,
+                         "Blocked": 6,
+                         "Clean Failed": 7,
+                         "Quarantine Failed": 102,
+                         "Remove Failed": 103,
+                         "Allow Failed": 104,
+                         "Abandoned": 105,
+                         "Blocked Failed": 107,
+                     }}],
+                ["__Search", 241, "String", {"length": 1024, "term_hex":"0A00000015"}],
+                ["SourceType", "x => len(list=x.__Search) + 249", "String", {"encoding": "utf16"}],
+                ["__FullPathLength", "x => len(list=x.__Search) + 265", "uint8"],
+                ["FullPath", "x => len(list=x.__Search) + 273", "String", {"length":"x=> x.__FullPathLength - 2", "encoding":"utf16"}],
+                ["__Sha256Search", 300, "String", {"length": 1024, "term_hex":"53006800610032"}],
+                ["Sha256", "x => len(list=x.__Sha256Search) + 322", "String", {"length": 128, "encoding":"utf16"}],
+                ["__TimeSearch", 300, "String", {"length": 1024, "term_hex":"540069006D0065"}],
+                ["Time", "x => len(list=x.__TimeSearch) + 314", "WinFileTime"],
+                ["__FileSizeSearch", 300, "String", {"length": 4000, "max_length": 4000, "term_hex":"530069007A0065"}],
+                ["ThreatFileSize", "x => len(list=x.__FileSizeSearch) +  314", "uint32"],
+                ["__UserSearch", "x=> if(condition=Size > 1024, then=(Size - 1024), else=0)", "String", {"length": 1024, "term_hex":"0000080000000A0000"}],
+                ["__Section3Offset", 0, "Value", {"value": "x => if(condition=Size > 1024, then=len(list=x.__UserSearch) + (Size - 1024), else=len(list=x.__UserSearch)) + 114" }],
+                ["User", "x => x.__Section3Offset", "String", {"encoding": "utf16"}],
+                ["__SearchStartingProcess", "x=> x.__Section3Offset + len(list=x.User)", "String", {"length": 1024, "term_hex": "0000150000"}],
+                ["StartingProcess", "x=> x.__Section3Offset + len(list=x.User) + len(list=x.__SearchStartingProcess) + 6", "String", {"encoding": "utf16"}]
+            ]],
+            ["GUIDStruct", 16, [
+              ["__D1", 0, "uint32"],
+              ["__D2", 4, "uint16"],
+              ["__D3", 6, "uint16"],
+              ["__D4", 8, "String", {"term": "", "length": 2}],
+              ["__D5", 10, "String", {"term": "", "length": 6}],
+              ["DetectionID", 0, "Value", {"value": "x=>format(format='{%x-%x-%x-%x-%x}', args=[x.__D1, x.__D2, x.__D3, x.__D4, x.__D5])"}]
+             ]],
+          ]
+          '''
+    
+            Let temp = SELECT FullPath, 
+                  Size,    
+                  parse_binary(filename=FullPath, profile = profile, struct = 'Info') as parsedfile 
+            FROM glob(globs = TargetGlob)
+            
+            SELECT  parsedfile.Time as EventTime,
+                    parsedfile.ThreatType as ThreatType,
+                    parsedfile.ThreatStatusID as ThreatStatus,
+                    parsedfile.FullPath as FullPath,
+                    parsedfile.Sha256 as Sha256,
+                    parsedfile.SourceType as SourceType,
+                    parsedfile.ThreatFileSize as FileSizeBytes,
+                    parsedfile.User as User,
+                    parsedfile.StartingProcess as StartingProcess,
+                    FullPath as ParsedFileFullPath
+            FROM temp


### PR DESCRIPTION
This artifact parses the Windows Defender files generated on threat detection and returns the contained parameters created by Windows Defender about the detected threat. 

By default with no parameters DefenderHistory parses "C:/ProgramData/Microsoft/Windows Defender/Scans/History/Service/DetectionHistory/**" A different TargetGlob can be entered.