### PR TITLE
Update artifact for Chainsaw v.1.1.7

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Chainsaw.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Chainsaw.yaml
@@ -14,11 +14,17 @@ description: |
     logic and via support for Sigma detection rules."
 
     https://github.com/countercept/chainsaw
+    
+    **WARNING!** As of the latest version of Chainsaw, 
+    there is a [bug](https://github.com/countercept/chainsaw/pull/62) 
+    that does not return all of Chainsaw's "builtin detections" 
+    via JSON output which means this VQL artifact is likely not 
+    to return complete detection results until the bug is fixed!
 
 author: Wes Lambert - @therealwlambert
 tools:
   - name: Chainsaw
-    url: https://github.com/countercept/chainsaw/releases/download/v1.0.2/chainsaw_x86_64-pc-windows-msvc.zip
+    url: https://github.com/countercept/chainsaw/releases/download/v1.1.7/chainsaw_x86_64-pc-windows-msvc.zip
 parameters:
   - name: EVTXPath
     default: 'C:\Windows\System32\winevt\Logs'
@@ -39,7 +45,8 @@ sources:
         Let ExecCS <= SELECT * FROM execve(argv=[
                         TmpDir + '/chainsaw/chainsaw.exe',
                         'hunt', EVTXPath,
-                        "--json", TmpResults,
+                        "--json",
+                        "--output", TmpResults,
                         "--rules", SigmaRules,
                         "--mapping", SigmaMapping], length=Length)
         LET Data = SELECT * FROM foreach(row=Results, query={SELECT parse_json_array(data=Data) AS Content FROM scope()})


### PR DESCRIPTION
In my test case of this artifact, Chainsaw v.1.0.2 was returning very few detections (8) on a set of EVTX full of threats whereas v.1.1.7 returned 40+ detections. However, v.1.1.7 changed the behavior of the `--json` option which broke this original artifact. This VQL update replaces Chainsaw v.1.0.2 with v.1.1.7 and updates the CLI options. 

**WARNING!** As of the latest version of Chainsaw, there is a [bug](https://github.com/countercept/chainsaw/pull/62) that **does not return all detections via JSON output** which means **this VQL artifact is likely not to return complete detection results** until the bug is fixed! I have added this warning to the VQL description as it's very important for the analyst to know when using this artifact. Once the bug is confirmed fixed, we can update the download version and remove the warning. See [screenshot](https://twitter.com/eric_capuano/status/1527943034045874177?s=20&t=Ql8QSSH5slyJGBMtR2UQww).