### PR TITLE
Create KillProcess.yaml

### DIFF
--- a/content/exchange/artifacts/KillProcess.yaml
+++ b/content/exchange/artifacts/KillProcess.yaml
@@ -1,0 +1,45 @@
+name: Windows.Remediation.KillProcess
+author: Matt Green - @mgreen27
+description: |
+   Quick and dirty monitoring artifact to kill a process by Image Name.
+   We monitor the Microsoft-Windows-Kernel-Process ETW provider and leverage 
+   taskkill to kill the process.
+   
+   There are no guardrails on this artifact please be VERY careful adding new entries.
+
+type: CLIENT_EVENT
+
+parameters:
+   - name: ProcessToKill
+     type: csv
+     default: |
+        ImageRegex,Description
+        \\folder\\folder2\\file\.exe$,Example target image
+        \\psexesvc\.exe$,Default psexec executable on target machine.
+        \\calc\.exe$,Test fast running process: start > run calc.exe
+        \\calculator\.exe$,Test killing calc.exe alias (modern Windows calc.exe)
+        
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+      LET name_regex = join(array=ProcessToKill.ImageRegex,sep='|')
+      LET watch_processes = SELECT System.TimeStamp AS CreateTime,
+                   EventData.ImageName AS ImageName,
+                   int(int=EventData.ProcessID) AS Pid,
+                   EventData.MandatoryLabel AS MandatoryLabel,
+                   EventData.ProcessTokenElevationType AS ProcessTokenElevationType,
+                   EventData.ProcessTokenIsElevated AS TokenIsElevated
+        FROM watch_etw(guid="{22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716}", any=0x10)
+        WHERE System.ID = 1 AND ImageName =~ name_regex
+        
+      SELECT * FROM foreach(row=watch_processes,
+        query={
+            SELECT CreateTime,ImageName,Pid,MandatoryLabel,ProcessTokenElevationType,TokenIsElevated,
+                if(condition= ReturnCode=0,
+                    then= Stdout,
+                    else= 'There was a problem on tasklill attempt. ' + Stderr) as TaskKill
+            FROM execve(argv=["taskkill", "/PID", Pid, "/T", "/F"])
+        })


### PR DESCRIPTION
A quick and dirty monitoring artefact to kill a process.
Ran this recently as a best effort to mitigate ransomware deployment.