### PR TITLE
Hayabusa export as Timestamp instead of String

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -98,7 +98,7 @@ sources:
             
         LET UploadCSVResults <= SELECT *, FullPath, Size, Modifed, Type FROM UploadCSV
                        
-        LET Results <= SELECT *, timestamp(string=Timestamp) AS Timestamp FROM parse_csv(filename=CSVFile)
+        LET Results <= SELECT *, timestamp(string=Timestamp) AS EventTime FROM parse_csv(filename=CSVFile)
         
         SELECT * FROM Results
 

--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -98,7 +98,7 @@ sources:
             
         LET UploadCSVResults <= SELECT *, FullPath, Size, Modifed, Type FROM UploadCSV
                        
-        LET Results <= SELECT * FROM parse_csv(filename=CSVFile)
+        LET Results <= SELECT *, timestamp(string=Timestamp) AS Timestamp FROM parse_csv(filename=CSVFile)
         
         SELECT * FROM Results
 


### PR DESCRIPTION
The current export returns the Timestamp as a string. Force the column in the CSV to be converted to an actual Timestamp which Vir can handle