### PR TITLE
Patching Linux.Memory.Acquisition

### DIFF
--- a/content/exchange/artifacts/LinuxMemoryAcquisition.yaml
+++ b/content/exchange/artifacts/LinuxMemoryAcquisition.yaml
@@ -35,7 +35,7 @@ precondition: SELECT OS From info() where OS = 'linux'
 
 sources:
   - queries:
-    - LET Volatility = SELECT * FROM Artifact.Linux.Volatility.Create.Profile(Zipname=Zipname)
+    - LET Volatility = SELECT * FROM Artifact.Exchange.Linux.Volatility.Create.Profile(Zipname=Zipname)
 
       LET Lime = SELECT FullPath, Stdout, Stderr, if(condition=Complete, then=upload(file="/tmp/" + Dumpname + ".raw", name=Dumpname + ".raw")) As Upload FROM execve(argv=['bash', '-c', 'mv /tmp/master.zip /tmp/lime-master.zip ; unzip -o /tmp/lime-master.zip -d /tmp/ ; cd /tmp/LiME-master/src/ ; apt-get -y install build-essential linux-headers-$(uname -r) ; make ; insmod /tmp/LiME-master/src/lime-*.ko "path=/tmp/"' + Dumpname + '".raw format=lime"'])
 


### PR DESCRIPTION
The `Linux.Memory.Acquisition` artifact relies on another exchange artifact `Linux.Volatility.Create.Profile`. When exchange artifacts are imported, they get the prefix `Exchange` added to the their name. To reference an exchange artifact within an artifact definition this prefix must be present within the artifact definition. 

Without this fix, the artifact fails to launch due to `Artifact.Linux.Volatility.Create.Profile` not being defined.

Fixed by updating `Artifact.Linux.Volatility.Create.Profile` to `Artifact.Exchange.Linux.Volatility.Create.Profile`