### PR TITLE
Create UnattendXML.yaml

### DIFF
--- a/content/exchange/artifacts/UnattendXML.yaml
+++ b/content/exchange/artifacts/UnattendXML.yaml
@@ -1,0 +1,45 @@
+name: Windows.Detection.UnattendXML
+author: Matt Green - @mgreen27
+description: |
+   This artifact will find unscrubbed passwords in unattend.xml answer files. This 
+   file is used for non interactive Windows installation.
+
+reference:
+   - https://twitter.com/malmoeb/status/1561443455095771136
+   - https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs?view=windows-11
+
+parameters:
+   - name: TargetFileName
+     default: ^(unattend\.xml|autounattend\.xml|sysprep\.xml)$
+     type: regex
+     description: File names to target for unattend xml files.
+   - name: ExcludeString
+     default: ^\*SENSITIVE\*DATA\*DELETED\*$
+     description: regex to exclude
+   - name: UploadHits
+     description: select to upload file
+     type: bool
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows' 
+
+    query: |
+      LET targets = SELECT OSPath,FileName,LastModified0x10,Created0x10 FROM Artifact.Windows.NTFS.MFT(FileRegex=TargetFileName)
+
+      LET hits = SELECT * FROM foreach(row=targets,
+        query={
+          SELECT 
+            Type,Value,OSPath,
+            LastModified0x10 as ModificationTime,
+            Created0x10 as CreationTime,
+            parse_xml(file=OSPath).unattend as Xml
+          FROM  parse_records_with_regex(file=OSPath,regex='\\<(?P<Type>.*Password.*)\\>(?P<Value>[^<]+)\\</.*Password.*\\>')
+          WHERE NOT Value =~ ExcludeString      
+        })
+
+      LET upload_hits = SELECT *, upload(file=OSPath) as Upload FROM hits
+        
+      SELECT * FROM if(condition=UploadHits,
+        then= upload_hits,
+        else= hits )


### PR DESCRIPTION
This artefact will find unscrubbed passwords in unattend.xml answer files. This file is used for non interactive Windows installation.

reference:
   - https://twitter.com/malmoeb/status/1561443455095771136
   - https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs?view=windows-11