### PR TITLE
Create MagicWeb.yaml

### DIFF
--- a/content/exchange/artifacts/MagicWeb.yaml
+++ b/content/exchange/artifacts/MagicWeb.yaml
@@ -1,0 +1,72 @@
+name: Windows.Detection.MagicWeb
+author: Matt Green - @mgreen27
+description: |
+   This artifact will find evidence of NOBELIUM’s MagicWeb.
+   
+   The artifact consists of two checks:
+   
+   1. Search for non default PublicKeyToken references in the 
+   Microsoft.IdentityServer.Servicehost.exe.config file (31bf3856ad364e35 default).  
+   2. Search for untrusted authenticode Microsoft.IdentityServer.*.dll files
+
+reference:
+   - https://www.microsoft.com/security/blog/2022/08/24/magicweb-nobeliums-post-compromise-trick-to-authenticate-as-anyone/
+
+parameters:
+   - name: ConfigFileGlob
+     default: C:\Windows\{AD FS,ADFS}\Microsoft.IdentityServer.Servicehost.exe.config
+     description: File names to target
+   - name: ExcludeToken
+     default: ^31bf3856ad364e35$
+     type: regex
+     description: Legit tokens to exclude from results
+   - name: TargetDllGlob
+     default: 'C:\Windows\Microsoft.NET\assembly\**\Microsoft.IdentityServer.*.dll'
+   - name: UploadHits
+     description: select to upload file hits
+     type: bool
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows' 
+    query: |
+      LET targets = SELECT OSPath,Size,Mtime,Atime,Ctime,Btime
+        FROM glob(globs=ConfigFileGlob)
+
+      LET hits = SELECT * FROM foreach(row=targets,
+        query={
+          SELECT 
+            OSPath,Size,
+            dict(Mtime=Mtime,Atime=Atime,Ctime=Ctime,Btime=Btime) as Timestamps,
+            PublicKeyToken,
+            read_file(filename=OSPath) as Data
+          FROM  parse_records_with_regex(file=OSPath,regex='PublicKeyToken=(?P<PublicKeyToken>[^,]+),')
+          WHERE NOT PublicKeyToken =~ ExcludeToken
+          GROUP BY OSPath, PublicKeyToken
+        })
+
+      LET upload_hits = SELECT *, upload(file=OSPath) as Upload FROM hits
+        
+      SELECT *
+      FROM if(condition=UploadHits,
+        then= upload_hits,
+        else= hits )
+
+  - name: BinaryPayload
+    description: Searches for untrusted Microsoft.IdentityServer dll files
+    query: |
+      LET binaries = SELECT 
+            OSPath,Size,
+            authenticode(filename=OSPath).Trusted as Authenticode,
+            dict(Mtime=Mtime,Atime=Atime,Ctime=Ctime,Btime=Btime) as Timestamps,
+            parse_pe(file=OSPath) as PE,
+            hash(path=OSPath) as Hash
+        FROM glob(globs=TargetDllGlob)
+        WHERE Authenticode =~ 'untrusted'
+
+      LET upload_binaries = SELECT *, upload(file=OSPath) as Upload FROM binaries
+        
+      SELECT *
+      FROM if(condition=UploadHits,
+        then= upload_binaries,
+        else= binaries )


### PR DESCRIPTION
   This artifact will find evidence of NOBELIUM’s MagicWeb.
   
   The artifact consists of two checks:
   
   1. Search for non default PublicKeyToken references in the 
   Microsoft.IdentityServer.Servicehost.exe.config file (31bf3856ad364e35 default).  
   2. Search for untrusted authenticode Microsoft.IdentityServer.*.dll files
