### PR TITLE
Added MacOS.ParallelsVM.SuspendedMemory

### DIFF
--- a/content/exchange/artifacts/MacOS.ParallelsVM.SuspendedMemory.yaml
+++ b/content/exchange/artifacts/MacOS.ParallelsVM.SuspendedMemory.yaml
@@ -1,0 +1,40 @@
+name: MacOS.ParallelsVM.SuspendedMemory
+description: |
+   Looks for suspended Parallels VM owned by any user on a MacOS system. Can automatically upload the virtual memory files if found.
+   
+   If a "*.mem.sh" file exists, that VM is running and not suspended.
+   
+   **NOTE:** Uploading the Parallels memory file can take a while due to the size.
+
+type: CLIENT
+
+author: Brady Semm - @btsemm
+
+precondition: SELECT OS From info() where OS = 'darwin'
+
+parameters:
+  - name: ParallelsMemoryPath
+    default: "/Users/*/Parallels/*.pvm/{*.mem,*.mem.sh}"
+  - name: UploadFiles
+    type: bool
+
+sources:
+  - name: ParallelsMemoryFiles
+    query: |
+      LET ParallelsMemoryFiles <= SELECT parse_string_with_regex(regex="/Users/(?P<User>[^/]+)", string=FullPath).User AS User,
+          parse_string_with_regex(regex="/Users/[^/]+/Parallels/(?P<VMName>[^\.]+).pvm", string=FullPath).VMName AS VMName,
+          FullPath, File, Mtime, Size
+          FROM glob(globs=ParallelsMemoryPath)
+          
+      SELECT User, VMName, Mtime, Size, FullPath
+      FROM ParallelsMemoryFiles
+      
+  - name: Uploads
+    query: |
+      SELECT * FROM if(condition=UploadFiles,
+        then={
+            SELECT FullPath, User, VMName, Mtime,
+               upload(file=FullPath) as FileDetails
+            FROM ParallelsMemoryFiles
+            WHERE FullPath =~ ".*\.mem$"
+        })


### PR DESCRIPTION
Looks for suspended Parallels VM owned by any user on a MacOS system. Can automatically upload the virtual memory files if found.