### PR TITLE
Windows.Detection.ISOMount

### DIFF
--- a/content/exchange/artifacts/Windows.Detection.ISOMount
+++ b/content/exchange/artifacts/Windows.Detection.ISOMount
@@ -1,0 +1,30 @@
+name: Windows.Detection.ISOMount
+author: Conor Quinn - @ConorQuinn92
+description: |
+   Following Microsoft's decision to block macros by default on MS Office applications, threat actors are increasingly using container files such as ISO files to distribute malware. 
+   This artifact will extract evidence of .iso files being mounted that may be malicious from the Microsoft-Windows-VHDMP-Operational EventLog. 
+   The artifact targets the string ".iso" in event IDs: 1 (mount), 2 (unmount) and 12 (type, path, handle).
+   
+reference:
+  - https://nasbench.medium.com/finding-forensic-goodness-in-obscure-windows-event-logs-60e978ea45a3
+  - https://www.proofpoint.com/us/blog/threat-insight/how-threat-actors-are-adapting-post-macro-world 
+
+parameters:
+   - name: TargetGlob
+     default: '%SystemRoot%\System32\Winevt\Logs\Microsoft-Windows-VHDMP-Operational.evtx'
+   - name: TargetVSS
+     type: bool
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+      SELECT EventTime,
+        Computer,Channel,EventID,EventRecordID,Message,EventData,FullPath, UserPath
+      FROM Artifact.Windows.EventLogs.EvtxHunter(
+        EvtxGlob=TargetGlob,
+        IdRegex='^(1|2|12|22|23)$',
+        IocRegex='\.iso',
+        SearchVSS=TargetVSS)
+        WHERE EventData.VhdFileName =~ 'C:\\\\Users\\\\'


### PR DESCRIPTION
Following Microsoft's decision to block macros by default on MS Office applications, threat actors are increasingly using container files such as ISO files to distribute malware. This artifact will extract evidence of .iso files being mounted that may be malicious from the Microsoft-Windows-VHDMP-Operational EventLog. The artifact targets the string ".iso" in event IDs: 1 (mount), 2 (unmount) and 12 (type, path, handle).