### PR TITLE
Add auto-labeling of clients

### DIFF
--- a/content/exchange/artifacts/Server.Monitor.Autolabeling.Clients.yaml
+++ b/content/exchange/artifacts/Server.Monitor.Autolabeling.Clients.yaml
@@ -1,0 +1,33 @@
+name: Server.Monitor.Autolabeling.Clients
+author: Stephan Mikiss @StephMikiss
+description: |
+    This server side event monitoring artifact watches for new client enrollments and automatically labels them according to their domain roles.
+    
+    * Standalone & Member Workstations will get the label `Workstation` assigned.
+    * Standalone & Member Servers will get the label `Server` assigned.
+    * Primary & Backup Domain Controller will get the label `Domain Controller` assigned.
+    * Linux Systems will get the label `Linux` assigned.
+    
+    Relabeling of all clients even after they were enrolled can be achieved by starting a hunt for `Generic.Client.Info`. The labels are either Set or Cleared so it is fine to re-apply the label many times. See https://docs.velociraptor.app/knowledge_base/tips/automating_labels/
+    
+type: SERVER_EVENT
+sources:
+- query: |
+    
+    LET interrogations = SELECT *
+        FROM watch_monitoring(artifact="System.Flow.Completion")
+        WHERE Flow.artifacts_with_results =~ "Generic.Client.Info/WindowsInfo|Generic.Client.Info/BasicInformation"
+    
+    LET matches = SELECT * FROM switch(
+        z={SELECT *,label(client_id=ClientId, labels="Linux", op="set") FROM source(
+            artifact="Generic.Client.Info/BasicInformation") WHERE OS =~ "linux"},
+        a={SELECT *,label(client_id=ClientId, labels="Workstation", op="set") FROM source(
+            artifact="Generic.Client.Info/WindowsInfo") WHERE `Computer Info`.DomainRole =~"Workstation"},
+        b={SELECT *,label(client_id=ClientId, labels="Server", op="set") FROM source(
+            artifact="Generic.Client.Info/WindowsInfo") WHERE `Computer Info`.DomainRole =~"Server"},
+        c={SELECT *,label(client_id=ClientId, labels="Domain Controller", op="set") FROM source(
+            artifact="Generic.Client.Info/WindowsInfo") WHERE `Computer Info`.DomainRole =~"Domain Controller"}
+    )
+       
+    SELECT * FROM foreach(row=interrogations, query=matches)
+    


### PR DESCRIPTION
This server side event monitoring artifact watches for new client enrollments and automatically labels them according to their domain roles or OS types. This makes it easier to target hunts specifically at workstations, server or domain controller.