### PR TITLE
Create Linux.Forensics.RecentlyUsed.yaml

### DIFF
--- a/content/exchange/artifacts/Linux.Forensics.RecentlyUsed.yaml
+++ b/content/exchange/artifacts/Linux.Forensics.RecentlyUsed.yaml
@@ -1,0 +1,48 @@
+name: Linux.Forensics.RecentlyUsed
+description: |
+  Parses the 'recently-used.xbel' XML file for all standard Linux users.
+  
+  This file notably records a list of recent files accessed by applications and is also an alternative source for download history.
+
+author: Deepak Sharma - @rxurien
+
+type: CLIENT
+
+precondition: SELECT OS From info() where OS = 'linux'
+
+parameters:
+  - name: RecentsFile
+    default: '.local/share/recently-used.xbel'
+    
+sources:
+  - name: Recent Entries
+    query: |
+        LET ParseBookmarks = SELECT * from foreach(
+          row={
+             SELECT Uid, User, Homedir from Artifact.Linux.Sys.Users()
+          },
+          query={
+             SELECT FullPath, Mtime, Ctime, User, Uid
+             FROM glob(
+               globs=RecentsFile,
+               root=Homedir)
+          })
+
+        SELECT * from foreach(
+          row=ParseBookmarks,
+          query={
+            SELECT 
+                User,
+                Uid as UID,
+                _value.Attrhref as FilePath,
+                _value.Attradded as TimeAdded,
+                _value.Attrmodified as TimeModified,
+                _value.Attrvisited as TimeVisited,
+                _value.info.metadata.`mime-type`.Attrtype as MimeType,
+                _value.info.metadata.applications.application.Attrname as ApplicationName,
+                _value.info.metadata.applications.application.Attrexec as ApplicationExec,
+                _value.info.metadata.applications.application.Attrmodified as ApplicationModTime,
+                _value.info.metadata.applications.application.Attrcount as ApplicationCount,
+                FullPath as SourceFile
+            FROM items(item=parse_xml(file=FullPath).xbel.bookmark)
+          })


### PR DESCRIPTION
Parses the 'recently-used.xbel' XML file for all standard Linux users.

This file notably records a list of recent files accessed by applications and is also an alternative source for download history.