### PR TITLE
Create ManageEngineLog.yaml

### DIFF
--- a/content/exchange/artifacts/ManageEngineLog.yaml
+++ b/content/exchange/artifacts/ManageEngineLog.yaml
@@ -1,0 +1,56 @@
+name: Generic.Detection.ManageEngineLog
+author: Matt Green - @mgreen27
+description: |
+   This artifact will enable discovery of associated with observed exploitation 
+   of critical ManageEngine vulnerability: CVE-2022-47966.
+   
+   The artifact leverages Yara.Glob to scan ManageEngine logs and is cross 
+   platform.
+
+
+type: CLIENT
+
+parameters:
+   - name: TargetLogGlob
+     default: "**/{access_log,serverout*.txt}"
+   - name: YaraRule
+     default: |
+        rule LOG_EXPL_ManageEngine_CVE_2022_47966_Jan23 {
+           meta:
+              description = "Detects Exploitation of Critical ManageEngine Vulnerability: CVE-2022-47966"
+              author = "Matt Green - @mgreen27"
+              reference = "https://www.rapid7.com/blog/post/2023/01/19/etr-cve-2022-47966-rapid7-observed-exploitation-of-critical-manageengine-vulnerability/"
+              date = "2023-01-20"
+           strings:
+             $s1 = "com.adventnet.authentication.saml.SamlException: Signature validation failed. SAML Response rejected" 
+
+             $re1 = /invalid_response --> .{20,}/s  //Logging typically contains this string followed by Base64 <samlp:Response Version=
+             
+             $ip1 = "111.68.7.122"
+             $ip2 = "149.28.193.216"
+             $ip3 = "172.93.193.64"
+             
+            condition:
+              any of them
+        }
+   - name: Context
+     default: 200
+     description: Amount of ContextBytes to include on each hit.
+   - name: NumberOfHits
+     default: 9999
+     description: Maximum number of hits to return
+   - name: UploadHits
+     type: bool
+     description: Upload each file with a hit.
+        
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows' OR OS = 'linux' OR OS = 'darwin'
+
+    query: |
+      SELECT * FROM Artifact.Generic.Detection.Yara.Glob(
+                                        PathGlob=TargetLogGlob,
+                                        YaraRule=YaraRule,
+                                        ContextBytes=Context,
+                                        NumberOfHits=9999,
+                                        UploadHits=UploadHits)


### PR DESCRIPTION
First round of content for https://www.rapid7.com/blog/post/2023/01/19/etr-cve-2022-47966-rapid7-observed-exploitation-of-critical-manageengine-vulnerability/