### PR TITLE
update hayabusa artifact

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -4,47 +4,58 @@ description: |
    
    This artifact runs Hayabusa on the endpoint against the specified Windows event log directory, and generates and uploads a single CSV file for further analysis with excel, timeline explorer, elastic stack, etc.
 
-author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack
+author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity
 
 tools:
  - name: Hayabusa
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v1.4.1/hayabusa-1.4.1-windows-64-bit.zip
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.1.0/hayabusa-2.1.0-win-64-bit.zip
 
 precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:
- - name: EVTXPath
-   description: "Path to the event logs for scanning"
-   default: C:\Windows\System32\winevt\Logs
  - name: UTC
    description: "Output time in UTC format"
    type: bool
    default: Y
  - name: UpdateRules
-   description: "Update rules to latest before scanning logs"
+   description: "Update rules before scanning"
    type: bool
- - name: DeprecatedRules
-   description: "Enable rules marked as deprecated"
-   type: bool
+   default: Y
  - name: NoisyRules
    description: "Enable rules marked as noisy"
    type: bool
- - name: FullData
-   description: "Return original event content instead of just the detection - VERBOSE!"
+   default: N
+ - name: OutputProfile
+   description: "Decide how much data you want back"
+   default: standard
+   type: choices
+   choices:
+     - minimal
+     - standard
+     - verbose
+     - all-field-info
+     - all-field-info-verbose
+     - super-verbose
+     - timesketch-minimal
+     - timesketch-verbose
+ - name: EIDFilter
+   description: "Scan only common Event IDs for quicker scans"
    type: bool
- - name: DeepScan
-   description: "Scan ALL event IDs, not just those which apply to known rules."
-   type: bool
- - name: MinLevel
+   default: N
+ - name: MinimalLevel
    description: "Minimum level for rules"
    default: informational
    type: choices
    choices:
      - informational
-     - critical
-     - high
-     - med
      - low
+     - medium
+     - high
+     - critical
+ - name: Threads
+   description: "Number of threads"
+   type: int
+   default: 2
 
 sources:
  - query: |
@@ -55,40 +66,25 @@ sources:
 
         LET UnzipIt <= SELECT * FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
 
-        LET HayabusaExe <= TmpDir + '\\hayabusa-1.4.1-win-x64.exe'
-
-        LET ConfigPath <= TmpDir + '\\rules\\config'
-
-        LET RulesPath <= TmpDir + '\\rules'
+        LET HayabusaExe <= TmpDir + '\\hayabusa-2.1.0-win-x64.exe'
        
-        LET BackupRules <= if(condition=UpdateRules, then={
-                                                    SELECT *
-                                                    FROM execve(argv=['cmd.exe', '/c',
-                                                    'ren',RulesPath,'rules_old'])
-                                                    })
-        
-        LET Update_Rules <= if(condition=UpdateRules, then={
-                                                    SELECT *
-                                                    FROM execve(argv=['cmd.exe', '/c', 'cd', TmpDir, '&', HayabusaExe, '-u'])
-                                                    })
+        LET Update_Rules <= if(condition=UpdateRules, then={ SELECT * FROM execve(argv=['cmd.exe', '/c', 'cd', TmpDir, '&', HayabusaExe, 'update-rules']) })
 
         LET Random <= rand(range=100000000000)
         
         LET CSVFile <= TmpDir + '\\hayabusa_results_'+str(str=Random)+'.csv'
 
         LET cmdline <= array(a=HayabusaExe)
-        LET cmdline <= cmdline + ("-d", EVTXPath,
-                                  "-o", CSVFile,
-                                  "-r", RulesPath,
-                                  "-m", MinLevel,
-                                  "-q")
+        LET cmdline <= cmdline + ("csv-timeline", "--live-analysis",
+                                  "--output", CSVFile,
+                                  "--min-level", MinimalLevel,
+                                  "--profile", OutputProfile,
+                                  "--quiet", "--no-summary",
+                                  "--thread-number", Threads)
 
-        LET cmdline <= if(condition=UTC, then=cmdline + array(a="-U"), else=cmdline)
-        LET cmdline <= if(condition=DeprecatedRules, then=cmdline + array(a="-D"), else=cmdline)
-        LET cmdline <= if(condition=NoisyRules, then=cmdline + array(a="-n"), else=cmdline)
-        LET cmdline <= if(condition=FullData, then=cmdline + array(a="-F"), else=cmdline)
-        LET cmdline <= if(condition=DeepScan, then=cmdline + array(a="-D"), else=cmdline)
-
+        LET cmdline <= if(condition=UTC, then=cmdline + array(a="--UTC"), else=cmdline)
+        LET cmdline <= if(condition=NoisyRules, then=cmdline + array(a="--enable-noisy-rules"), else=cmdline)
+        LET cmdline <= if(condition=EIDFilter, then=cmdline + array(a="--eid-filter"), else=cmdline)
 
         LET ExecHB <= SELECT * FROM execve(argv=cmdline, sep="\n", length=9999999)
                        
@@ -101,4 +97,3 @@ sources:
         LET Results <= SELECT *, timestamp(string=Timestamp) AS EventTime FROM parse_csv(filename=CSVFile)
         
         SELECT * FROM Results
-


### PR DESCRIPTION
This PR updates the Hayabusa artifact from using version 1.4.1 to the latest 2.1.0 which provides better performance, accuracy as well as rule updates. (The rule update feature on 1.4.1 broke sometime in the past)