### PR TITLE
Update Generic.Collection.UAC.yaml

### DIFF
--- a/content/exchange/artifacts/Generic.Collection.UAC.yaml
+++ b/content/exchange/artifacts/Generic.Collection.UAC.yaml
@@ -26,7 +26,7 @@ parameters:
 sources:
     - query: |
         // fetch .tar.gz package
-        LET uac_package <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(ToolName="uac")
+        LET uac_package <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(ToolName="uac", IsExecutable=FALSE)
         // create temp dir
         LET temp_dir <= tempdir(remove_last=true)
         // uncompress the .tar.gz container

--- a/content/exchange/artifacts/Generic.Collection.UAC.yaml
+++ b/content/exchange/artifacts/Generic.Collection.UAC.yaml
@@ -12,7 +12,8 @@ type: CLIENT
 
 tools:
     - name: uac
-      url: https://github.com/tclahr/uac/archive/main.zip
+      github_project: tclahr/uac
+      github_asset_regex: uac-.+\.tar\.gz
 
 precondition: SELECT OS FROM info() WHERE OS = "darwin" OR OS = "freebsd" OR OS = "linux"
 
@@ -21,35 +22,38 @@ parameters:
       default: -p ir_triage
       type: string
       description: Command line options.
-    - name: Destination
-      default: uac_destination_dir
-      type: string
-      description: Specify the temporary directory the output file should be copied to.
 
 sources:
     - query: |
-        LET download_zip <= SELECT FullPath FROM Artifact.Generic.Utils.FetchBinary(ToolName="uac")
+        // fetch .tar.gz package
+        LET uac_package <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(ToolName="uac")
+        // create temp dir
         LET temp_dir <= tempdir(remove_last=true)
-        LET unzip_file <= SELECT * FROM unzip(filename=download_zip[0].FullPath, output_directory=temp_dir)
-        LET create_destination_dir <= SELECT * FROM execve(argv=[
-                "mkdir",
-                "-p",
-                temp_dir + "/" + Destination
-            ]
-        )
+        // uncompress the .tar.gz container
+        LET uncompress_tar_gz <= SELECT * FROM execve(argv=['tar', 'zxf', uac_package.FullPath[0]], cwd=temp_dir)
+        // search for the correct uac source directory name
+        LET uac_source_directory <= SELECT FullPath FROM glob(globs=["uac-*"], root=temp_dir) WHERE IsDir = true
+        // run uac
         LET run_uac <= SELECT * FROM execve(argv=[
-                "/bin/sh",
-                "-c",
-                "./uac " + CommandLineOptions + " " + temp_dir + "/" + Destination
-            ],
-            cwd=temp_dir + "/" + "uac-main",
-            sep="\n",
-            length=2048
-        )
-        LET find_output_files <= SELECT * FROM glob(globs=["uac*"], root=temp_dir + "/" + Destination)
+                                                "/bin/sh",
+                                                "-c",
+                                                "./uac -u " + CommandLineOptions + " ."
+                                            ],
+                                            cwd=uac_source_directory.FullPath[0],
+                                            sep="\n",
+                                            length=2048
+                                        )
+        // find the output files
+        LET find_output_files <= SELECT FullPath FROM glob(globs=["uac-*.log", "uac-*.tar.gz"], root=uac_source_directory.FullPath[0])
+        // upload the output files
         LET upload_output_files <= SELECT upload(accessor="file", file=FullPath) AS Upload FROM find_output_files
         SELECT * FROM chain(
             a=run_uac,
             b=upload_output_files
         )
-        
+
+# CHANGELOG:
+# 2023-03-01: v2.0 released
+#   - UAC tool needs to be either fetched via upstream URL or manually provided as a .tar.gz package.
+# 2023-02-19: v1.0 released
+#   - Initial release.


### PR DESCRIPTION
Zip package support was dropped. UAC tool now needs to be either fetched via upstream URL or manually provided as a .tar.gz package.