### PR TITLE
Update Windows.Applications.AnyDesk.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Applications.AnyDesk.yaml
+++ b/content/exchange/artifacts/Windows.Applications.AnyDesk.yaml
@@ -69,7 +69,7 @@ sources:
         FROM parse_lines(filename=FullPath) 
 
       -- function returning IOC hits
-      LET logsearch(FileGlob) = SELECT * FROM foreach(
+      LET logsearch(PathList) = SELECT * FROM foreach(
             row=PathList,
             query={
                SELECT *,timestamp(epoch=Record.Timestamp,format="2006-01-02 15:04:05") AS Timestamp


### PR DESCRIPTION
The variable 'FileGlob' did not exist which resulted in the error: "Extra unrecognized arg PathList when calling logsearch"