### PR TITLE
Add missing opening brace to Exchange.Windows.ActiveDirectory.PrivilegedUsers

### DIFF
--- a/content/exchange/artifacts/ActiveDirectoryPrivilegedUsers.yaml
+++ b/content/exchange/artifacts/ActiveDirectoryPrivilegedUsers.yaml
@@ -40,7 +40,7 @@ sources:
                   }
 
                   $userdetails = @()
-                  foreach ($user in ($users | Sort-Object | Get-Unique))
+                  foreach ($user in ($users | Sort-Object | Get-Unique)) {
                     $userdetails += Get-ADUser -Identity $user -Properties *
                   }
 


### PR DESCRIPTION
Fixes missing opening brace from nested loop in the artifact exchange's Windows.ActiveDirectory.PrivilegedUsers hunt.