### PR TITLE
Create Server.Telegram.Clients.Enrolled.yaml

### DIFF
--- a/content/exchange/artifacts/Server.Telegram.Clients.Enrolled.yaml
+++ b/content/exchange/artifacts/Server.Telegram.Clients.Enrolled.yaml
@@ -1,0 +1,81 @@
+name: Server.Telegram.Clients.Enrolled
+author: "td - @tuedenn"
+description: |
+   Send a message to telegram when clients become enrolled.
+
+   This artifact triggers when a client is interrogated within 60
+   seconds of it being seen for the first time. You can manually 
+   configure information such as FirstSeenDelay, timestamp, etc.
+   
+   Inspired by `Server.Slack.Clients.Enrolled`.
+type: SERVER_EVENT
+
+parameters:
+  - name: FirstSeenDelay
+    default: "60"
+    type: int
+    description: |
+        The time between first_seen_time and Generic.Client.Info collection.
+  - name: TeleChatID
+    description: |
+        The chat_id of the group chat you want to send messages to.
+        e.g: -872161xxx
+  - name: TeleURL
+    description: |
+        The url of your bot API be used to send message.
+        e.g: https://api.telegram.org/bot66666xxxxx:AAGukJg5LXgPkxxxtVU2Smbtrf0tnVuNxxx/sendMessage
+
+sources:
+  - query: |
+        LET chatID = if(
+                   condition=TeleChatID,
+                   then=TeleChatID,
+                   else=server_metadata().TeleID)
+                   
+        LET urlTele = if(
+                   condition=TeleURL,
+                   then=TeleURL,
+                   else=server_metadata().TeleURL)
+
+        -- Returns an event for each interrogation that occurs within 60 seconds
+        -- of first seen timestamp.
+        
+        LET completions = SELECT client_id AS ClientId,
+                         os_info.hostname AS Hostname,
+                         os_info.fqdn AS Fqdn,
+                         last_ip AS LastIP,
+                         os_info.system AS OS,
+                         os_info.release AS OSrelease,
+                         timestamp(epoch=first_seen_at) AS FirstSeen,
+                         timestamp(epoch=last_seen_at) AS LastSeen,
+                         timestamp(epoch=now()) AS Now
+        FROM clients()
+        WHERE last_interrogate_artifact_name = "Generic.Client.Info/BasicInformation"
+        AND first_seen_at > now() - FirstSeenDelay
+
+        -- Sends the message to a telegram group.
+        LET SendToTele(Message) = SELECT *
+            FROM http_client(
+              method="POST",
+              headers=dict(`Content-Type`="application/json"),
+              data=serialize(
+              format="json", item=dict(chat_id=chatID, text=Message)),
+              url=urlTele)
+
+        LET send_massage = SELECT * 
+        FROM foreach(
+          row=completions, 
+          query={
+            SELECT Content, Response, Headers.Date
+            FROM SendToTele(
+              Message=format(
+                format="[Info] New client has been enrolled!\nTime: %v!\nHostname: %s\nIP: %s\nOS: %v",
+                args=[FirstSeen, Hostname, LastIP, OSrelease]))
+        })
+        
+        -- Check every minute using clock() plugin
+        SELECT * FROM foreach(
+        row={
+          SELECT * FROM clock(period=FirstSeenDelay
+          )},
+        query=send_massage)


### PR DESCRIPTION
Using clock() plugin to monitor every minute instead of watch_monitoring(), then send to the telegram chat group