### PR TITLE
Create Generic.Remediation.UploadFile.Glob.yaml

### DIFF
--- a/content/exchange/artifacts/Generic.Remediation.UploadFile.Glob.yaml
+++ b/content/exchange/artifacts/Generic.Remediation.UploadFile.Glob.yaml
@@ -1,0 +1,34 @@
+name: Generic.Remediation.UploadFile.Glob
+description: |
+   This artefact lets you upload a file to the target system. If the target file exists, it will be overridden.
+   It uses glob to define the destination path. You can upload the file to multiple destinations at once.
+
+type: CLIENT
+
+parameters:
+   - name: TargetGlob
+     description: Destination Path, if the destination already exists, it will be overridden
+   - name: ReallyDoIt
+     description: When selected, it will really override the targets!
+     type: bool
+     
+tools:
+  - name: RemediationFile
+    url:
+
+sources:
+  - query: |
+      LET targets = SELECT * FROM glob(globs=TargetGlob)
+        WHERE NOT if(condition=TRUE,
+                then= IsDir,
+                else= FALSE)
+        ORDER BY OSPath DESC 
+     
+      LET UploadedFile <= SELECT FullPath FROM Artifact.Generic.Utils.FetchBinary(ToolName="RemediationFile", IsExecutable=FALSE, TemporaryOnly=TRUE)
+     
+      LET upload_targets = SELECT *, copy(filename=UploadedFile.FullPath[0], accessor="file", dest=OSPath) as Overridden FROM targets
+
+      SELECT OSPath,Overridden,Size,Mtime,Ctime,Btime,IsDir,IsLink
+      FROM if(condition=ReallyDoIt,
+            then= upload_targets,
+            else= { SELECT *, FALSE as Overridden FROM upload_targets } )

--- a/content/exchange/artifacts/Generic.Remediation.UploadFile.Glob.yaml
+++ b/content/exchange/artifacts/Generic.Remediation.UploadFile.Glob.yaml
@@ -19,9 +19,7 @@ tools:
 sources:
   - query: |
       LET targets = SELECT * FROM glob(globs=TargetGlob)
-        WHERE NOT if(condition=TRUE,
-                then= IsDir,
-                else= FALSE)
+        WHERE NOT IsDir
         ORDER BY OSPath DESC 
      
       LET UploadedFile <= SELECT FullPath FROM Artifact.Generic.Utils.FetchBinary(ToolName="RemediationFile", IsExecutable=FALSE, TemporaryOnly=TRUE)

--- a/content/exchange/artifacts/Generic.Remediation.UploadFile.Glob.yaml
+++ b/content/exchange/artifacts/Generic.Remediation.UploadFile.Glob.yaml
@@ -1,8 +1,8 @@
 name: Generic.Remediation.UploadFile.Glob
 description: |
-   This artefact lets you upload a file to the target system. If the target file exists, it will be overridden.
+   This artefact lets you upload a file to the target system. If the target file exists, it will be overritten.
    It uses glob to define the destination path. You can upload the file to multiple destinations at once.
-
+author: Philipp Leu
 type: CLIENT
 
 parameters:
@@ -24,9 +24,7 @@ sources:
      
       LET UploadedFile <= SELECT FullPath FROM Artifact.Generic.Utils.FetchBinary(ToolName="RemediationFile", IsExecutable=FALSE, TemporaryOnly=TRUE)
      
-      LET upload_targets = SELECT *, copy(filename=UploadedFile.FullPath[0], accessor="file", dest=OSPath) as Overridden FROM targets
-
-      SELECT OSPath,Overridden,Size,Mtime,Ctime,Btime,IsDir,IsLink
-      FROM if(condition=ReallyDoIt,
-            then= upload_targets,
-            else= { SELECT *, FALSE as Overridden FROM upload_targets } )
+      LET upload_targets = SELECT *, if(condition=ReallyDoIt, then=copy(filename=UploadedFile.FullPath[0], accessor="file", dest=OSPath), else=FALSE) AS Overwritten FROM targets
+      
+      SELECT OSPath,Overwritten,Size,Mtime,Ctime,Btime
+      FROM upload_targets 


### PR DESCRIPTION
Create an artifact to upload a file to the target destination. If the target already exists, it will be overridden.  The artefact uses the glob, so you can upload the file to multiple locations at once.