### PR TITLE
Add detection for memory based exec with memfd_create() on Linux

### DIFF
--- a/content/exchange/artifacts/Linux.Detection.MemFD.yaml
+++ b/content/exchange/artifacts/Linux.Detection.MemFD.yaml
@@ -4,7 +4,8 @@ description: |
    This artifact will parse /proc/*/exe files and look for processes 
     that have been executed from memory via memfd_create()
 
-reference: https://github.com/4ltern4te/velociraptor-contrib/blob/main/Linux.Detection.MemFD/README.md
+reference: 
+  - https://github.com/4ltern4te/velociraptor-contrib/blob/main/Linux.Detection.MemFD/README.md
 
 type: CLIENT
 

--- a/content/exchange/artifacts/Linux.Detection.MemFD.yaml
+++ b/content/exchange/artifacts/Linux.Detection.MemFD.yaml
@@ -1,0 +1,27 @@
+name: Linux.Detection.MemFD
+author: alternate
+description: |
+   This artifact will parse /proc/*/exe files and look for processes 
+    that have been executed from memory via memfd_create()
+
+reference: https://github.com/4ltern4te/velociraptor-contrib/blob/main/Linux.Detection.MemFD/README.md
+
+type: CLIENT
+
+precondition: SELECT OS From info() where OS = "linux"
+
+parameters:
+  - name: FileNameGlob
+    description: Glob pattern to search
+    default: "/proc/*/exe"
+    type: str
+
+  - name: SearchRegex
+    description: Pattern to match looking for memfd executions
+    default: ^\/memfd:.*?\(deleted\)
+    type: regex
+
+sources:
+- name: findMemFD
+  query: |
+    SELECT * FROM glob(globs=FileNameGlob, accessor='file') WHERE Data.Link =~ SearchRegex


### PR DESCRIPTION
Tested with PoC code here: https://github.com/4ltern4te/velociraptor-contrib/tree/main/Linux.Detection.MemFD on Fedora 37