### PR TITLE
Linux.Detection.SSHKeyFileCmd for SSH key file persistence detection

### DIFF
--- a/content/exchange/artifacts/Linux.Detection.SSHKeyFileCmd.yaml
+++ b/content/exchange/artifacts/Linux.Detection.SSHKeyFileCmd.yaml
@@ -1,0 +1,32 @@
+name: Linux.Detection.SSHKeyFileCmd
+author: alternate
+
+reference: 
+  - https://github.com/4ltern4te/velociraptor-contrib/blob/main/Linux.Detection.SSHKeyFileCmd/README.md
+  - https://blog.thc.org/infecting-ssh-public-keys-with-backdoors
+  - https://man.openbsd.org/OpenBSD-current/man8/sshd.8#AUTHORIZED_KEYS_FILE_FORMAT
+
+type: CLIENT
+
+precondition: SELECT OS From info() where OS = "linux"
+
+parameters:
+  - name: SSHKeyFilesGlob
+    default: |
+      ["/{root,home/*}/.ssh/authorized_keys","/{root,home/*}/.ssh/authorized_keys2","/{root,home/*}/.ssh/*.pub"]
+
+  - name: CommandRegex
+    description: Command option regex
+    default: (?P<CMD>command=".*?")
+    type: regex
+
+sources:
+  - name: findSSHAuthKeyCmd
+    query: |
+      LET files = SELECT OSPath FROM glob(globs=parse_json_array(data=SSHKeyFilesGlob))
+      SELECT OSPath, CMD FROM foreach(
+          row=files,
+          query={
+            SELECT OSPath, CMD FROM parse_records_with_regex(file=OSPath, regex=CommandRegex)
+          }
+      )

--- a/content/exchange/artifacts/Linux.Detection.SSHKeyFileCmd.yaml
+++ b/content/exchange/artifacts/Linux.Detection.SSHKeyFileCmd.yaml
@@ -1,5 +1,9 @@
 name: Linux.Detection.SSHKeyFileCmd
 author: alternate
+description: |
+   This artifact will parse ~/.ssh/authorized_keys and ~/.ssh/id_*.pub looking for the command option
+   to detect potential persistence
+
 
 reference: 
   - https://github.com/4ltern4te/velociraptor-contrib/blob/main/Linux.Detection.SSHKeyFileCmd/README.md


### PR DESCRIPTION
Tested on Fedora 37. PoC details and details at https://github.com/4ltern4te/velociraptor-contrib/tree/main/Linux.Detection.SSHKeyFileCmd