### PR TITLE
Update PrintNightmare.yaml

### DIFF
--- a/content/exchange/artifacts/PrintNightmare.yaml
+++ b/content/exchange/artifacts/PrintNightmare.yaml
@@ -1,136 +1,52 @@
-name: Windows.Detection.PrintNightmare
-author: "Matt Green - @mgreen27"
+name: Windows.Registry.PrintNightmare
 description: |
-  This artifact returns any binaries in the Windows/spool/drivers/**
-  folders with an untrusted Authenticode entry.
+   CVE-2021-34527 or Windows Print Spooler Remote Code Execution Vulnerability
+   
+   A remote code execution vulnerability exists when the Windows Print Spooler service improperly performs privileged file operations. An attacker who successfully exploited this vulnerability could run arbitrary code with SYSTEM privileges. An attacker could then install programs; view, change, or delete data; or create new accounts with full user rights.
+   
+   According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1. 
+   
+   The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.
+   
+   This vulnerability can be exploited using the Evil Printer attack.
+   
+   Changing the registry values from 1 to 0 or Disabling the spooler when it's not in use is recommended as the next step after applying the patch.
+   The following VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
 
-  It can be used to hunt for dll files droped during exploitation of
-  CVE-2021-1675 - PrintNightmare.
+   
+   References:
+   
+   https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
 
-  To query all attached ntfs drives: check the AllDrives switch.
+   https://i.blackhat.com/USA21/Wednesday-Handouts/us-21-Diving-Into-Spooler-Discovering-Lpe-And-Rce-Vulnerabilities-In-Windows-Printer.pdf
 
-  I have added several filters to uplift search capabilities from the
-  original MFT artifact. Due to the multi-drive features, the MFTPath
-  will output the MFT path of the entry.
+   https://nvd.nist.gov/vuln/detail/CVE-2021-34527
 
-  Available filters include:
-  - FullPath regex
-  - FileName regex
-  - Time bounds to select files with a timestamp within time ranges
-  - FileSize bounds
+# Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT
+type: CLIENT
 
-  ![Sample output](https://github.com/mgreen27/velociraptor-docs/raw/patch-5/content/exchange/artifacts/PrintNightmare.png)
+author: Daksh Gajjar - @dakshgajjar
+
+precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:
-  - name: MFTFilename
-    default: "C:/$MFT"
-  - name: Accessor
-    default: ntfs
-    type: hidden
-  - name: PathRegex
-    description: "Regex search over FullPath."
-    default: Windows/System32/spool/drivers
-  - name: FileRegex
-    description: "Regex search over File Name"
-    default: .
-  - name: AllAuthenticode
-    type: bool
-    description: "Show all binaries despite Authenticode trusted status (default shows only untrusted)."
-  - name: DateAfter
-    type: timestamp
-    description: "search for events after this date. YYYY-MM-DDTmm:hh:ssZ"
-  - name: DateBefore
-    type: timestamp
-    description: "search for events before this date. YYYY-MM-DDTmm:hh:ssZ"
-  - name: SizeMax
-    type: int64
-    description: "Entries in the MFT under this size in bytes."
-  - name: SizeMin
-    type: int64
-    description: "Entries in the MFT over this size in bytes."
-  - name: AllDrives
-    type: bool
-    description: "Select MFT search on all attached ntfs drives."
-
+  - name: SearchRegistryGlob
+    default: \HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\**
+    description: Having NoWarningNoElevationOnInstall set to 1 makes your system vulnerable by design
 
 sources:
   - query: |
-      -- time testing
-      LET time_test(stamp) =
-            if(condition= DateBefore AND DateAfter,
-                then= stamp < DateBefore AND stamp > DateAfter,
-                else=
-            if(condition=DateBefore,
-                then= stamp < DateBefore,
-                else=
-            if(condition= DateAfter,
-                then= stamp > DateAfter,
-                else= True
-            )))
-
-
-      -- find all ntfs drives
-      LET ntfs_drives = SELECT FullPath + '/$MFT'as Path
-        FROM glob(globs="/*", accessor="ntfs")
-
-
-      -- function returning MFT entries
-      LET mftsearch(MFTPath) = SELECT
-            split(sep='\\$',string=MFTPath)[0] + FullPath as FullPath,
-            InUse,FileName,FileSize,
-            dict(
-                Created0x10 = Created0x10,
-                LastModified0x10 = LastModified0x10,
-                LastRecordChange0x10 = LastRecordChange0x10,
-                LastAccess0x10 = LastAccess0x10
-                ) as SI,
-            dict(
-                Created0x30 = Created0x10,
-                LastModified0x30 = LastModified0x10,
-                LastRecordChange0x30 = LastRecordChange0x10,
-                LastAccess0x30 = LastAccess0x10
-                ) as FN
-        FROM parse_mft(filename=MFTPath, accessor=Accessor)
-        WHERE NOT IsDir
-            AND FullPath =~ PathRegex
-            AND FileName =~ FileRegex
-            AND if(condition=SizeMax,
-                then=FileSize < atoi(string=SizeMax),
-                else=TRUE)
-            AND if(condition=SizeMin,
-                then=FileSize > atoi(string=SizeMin),
-                else=TRUE)
-            AND
-             ( time_test(stamp=Created0x10)
-            OR time_test(stamp=Created0x30)
-            OR time_test(stamp=LastModified0x10)
-            OR time_test(stamp=LastModified0x30)
-            OR time_test(stamp=LastRecordChange0x10)
-            OR time_test(stamp=LastRecordChange0x30)
-            OR time_test(stamp=LastAccess0x10)
-            OR time_test(stamp=LastAccess0x30))
-
-
-      -- include all attached drives
-      LET all_drives = SELECT * FROM foreach(row=ntfs_drives,
-            query={
-                SELECT *
-                FROM mftsearch(MFTPath=Path)
-                WHERE log(message="Processing " + Path)
-              })
-
-
-      -- return rows
-      SELECT *,
-            parse_pe(file=FullPath) as PE,
-            authenticode(filename=FullPath) as Authenticode,
-            hash(path=FullPath) as Hash
-      FROM if(condition=AllDrives,
-        then= all_drives,
-        else= {
-           SELECT * FROM mftsearch(MFTPath=MFTFilename)
-        })
-      WHERE PE
-        AND if(condition=AllAuthenticode,
-            then=TRUE,
-            else= NOT Authenticode.Trusted = 'trusted')
+        SELECT  Name as KeyName,
+                FullPath,
+                Data.type as KeyType, 
+                Data.value as KeyValue,
+                Sys,
+                ModTime as Modified
+        FROM glob(globs=SearchRegistryGlob, accessor='registry')
+        
+        WHERE KeyType = "DWORD"
+        AND KeyName =~ "NoWarningNoElevationOnInstall"
+                  
+column_types:
+  - name: Modified
+    type: timestamp

--- a/content/exchange/artifacts/PrintNightmare.yaml
+++ b/content/exchange/artifacts/PrintNightmare.yaml
@@ -1,26 +1,6 @@
 name: Windows.Registry.PrintNightmare
 description: |
-   CVE-2021-34527 or Windows Print Spooler Remote Code Execution Vulnerability
-   
-   A remote code execution vulnerability exists when the Windows Print Spooler service improperly performs privileged file operations. An attacker who successfully exploited this vulnerability could run arbitrary code with SYSTEM privileges. An attacker could then install programs; view, change, or delete data; or create new accounts with full user rights.
-   
-   According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1. 
-   
    The artefact scans the device registry to check if the aforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered vulnerable to exploitation.
-   
-   This vulnerability can be exploited using the Evil Printer attack.
-   
-   Changing the registry values from 1 to 0 or Disabling the spooler when it's not in use is recommended as the next step after applying the patch.
-   The following VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
-
-   
-   References:
-   
-   https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
-
-   https://i.blackhat.com/USA21/Wednesday-Handouts/us-21-Diving-Into-Spooler-Discovering-Lpe-And-Rce-Vulnerabilities-In-Windows-Printer.pdf
-
-   https://nvd.nist.gov/vuln/detail/CVE-2021-34527
 
 # Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT
 type: CLIENT

--- a/content/exchange/artifacts/PrintNightmare.yaml
+++ b/content/exchange/artifacts/PrintNightmare.yaml
@@ -6,7 +6,7 @@ description: |
    
    According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1. 
    
-   The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.
+   The artefact scans the device registry to check if the aforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered vulnerable to exploitation.
    
    This vulnerability can be exploited using the Evil Printer attack.
    


### PR DESCRIPTION
According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1. 
   
The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.

This vulnerability can be exploited using the Evil Printer attack.

The suggested VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
   
References:
   
https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527