### PR TITLE
Create Windows.Registry.PrintNightmare.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
+++ b/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
@@ -1,38 +1,20 @@
 name: Windows.Registry.PrintNightmare
 author: Daksh Gajjar
-description: |
-   According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1.
-   
-   The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable    to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.
-   
-   This vulnerability can be exploited using the Evil Printer attack.
-   
-   The suggested VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
-
-reference:
-   - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
-
+description: Looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
 type: CLIENT
-
 precondition: SELECT OS From info() where OS = 'windows'
-
 parameters:
   - name: SearchRegistryGlob
     description: Registry path
     default: \HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\**
-
 sources:
-   - query: |
-         SELECT  Name as KeyName,
-            FullPath,
-            Data.type as KeyType, 
-            Data.value as KeyValue,
-            Sys,
-            ModTime as Modified
-         FROM glob(globs=SearchRegistryGlob, accessor='registry')
-         WHERE KeyType = "DWORD"
-            AND KeyName =~ "NoWarningNoElevationOnInstall"
-                  
-column_types:
-   - name: Modified
-   - type: timestamp
+  - query: |
+    SELECT  Name as KeyName,
+      FullPath,
+      Data.type as KeyType, 
+      Data.value as KeyValue,
+      Sys,
+      ModTime as Modified
+    FROM glob(globs=SearchRegistryGlob, accessor='registry')
+    WHERE KeyType = "DWORD"
+      AND KeyName =~ "NoWarningNoElevationOnInstall"

--- a/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
+++ b/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
@@ -1,0 +1,32 @@
+name: Windows.Registry.PrintNightmare
+description: |
+   The artefact scans the device registry to check if the aforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered vulnerable to exploitation.
+
+# Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT
+type: CLIENT
+
+author: https://github.com/DakshGajjar
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: SearchRegistryGlob
+    default: \HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\**
+    description: Having NoWarningNoElevationOnInstall set to 1 makes your system vulnerable by design
+
+sources:
+  - query: |
+        SELECT  Name as KeyName,
+                FullPath,
+                Data.type as KeyType, 
+                Data.value as KeyValue,
+                Sys,
+                ModTime as Modified
+        FROM glob(globs=SearchRegistryGlob, accessor='registry')
+        
+        WHERE KeyType = "DWORD"
+        AND KeyName =~ "NoWarningNoElevationOnInstall"
+                  
+column_types:
+  - name: Modified
+    type: timestamp

--- a/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
+++ b/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
@@ -1,23 +1,52 @@
 name: Windows.Registry.PrintNightmare
-author: Daksh Gajjar
-description: Looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
+description: |
+   CVE-2021-34527 or Windows Print Spooler Remote Code Execution Vulnerability
+   
+   A remote code execution vulnerability exists when the Windows Print Spooler service improperly performs privileged file operations. An attacker who successfully exploited this vulnerability could run arbitrary code with SYSTEM privileges. An attacker could then install programs; view, change, or delete data; or create new accounts with full user rights.
+   
+   According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1. 
+   
+   The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.
+   
+   This vulnerability can be exploited using the Evil Printer attack.
+   
+   Changing the registry values from 1 to 0 or Disabling the spooler when it's not in use is recommended as the next step after applying the patch.
+   The following VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
+
+   
+   References:
+   
+   https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
+
+   https://i.blackhat.com/USA21/Wednesday-Handouts/us-21-Diving-Into-Spooler-Discovering-Lpe-And-Rce-Vulnerabilities-In-Windows-Printer.pdf
+
+   https://nvd.nist.gov/vuln/detail/CVE-2021-34527
+
+# Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT
 type: CLIENT
+
+author: Daksh Gajjar - @dakshgajjar
+
 precondition: SELECT OS From info() where OS = 'windows'
+
 parameters:
   - name: SearchRegistryGlob
-    description: Registry path
     default: \HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\**
+    description: Having NoWarningNoElevationOnInstall set to 1 makes your system vulnerable by design
+
 sources:
   - query: |
-    SELECT  Name as KeyName,
-      FullPath,
-      Data.type as KeyType, 
-      Data.value as KeyValue,
-      Sys,
-      ModTime as Modified
-    FROM glob(globs=SearchRegistryGlob, accessor='registry')
-    WHERE KeyType = "DWORD"
-      AND KeyName =~ "NoWarningNoElevationOnInstall"                
+        SELECT  Name as KeyName,
+                FullPath,
+                Data.type as KeyType, 
+                Data.value as KeyValue,
+                Sys,
+                ModTime as Modified
+        FROM glob(globs=SearchRegistryGlob, accessor='registry')
+        
+        WHERE KeyType = "DWORD"
+        AND KeyName =~ "NoWarningNoElevationOnInstall"
+                  
 column_types:
   - name: Modified
     type: timestamp

--- a/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
+++ b/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
@@ -17,4 +17,7 @@ sources:
       ModTime as Modified
     FROM glob(globs=SearchRegistryGlob, accessor='registry')
     WHERE KeyType = "DWORD"
-      AND KeyName =~ "NoWarningNoElevationOnInstall"
+      AND KeyName =~ "NoWarningNoElevationOnInstall"                
+column_types:
+  - name: Modified
+    type: timestamp

--- a/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
+++ b/content/exchange/artifacts/Windows.Registry.PrintNightmare.yaml
@@ -1,32 +1,38 @@
 name: Windows.Registry.PrintNightmare
+author: Daksh Gajjar
 description: |
-   The artefact scans the device registry to check if the aforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered vulnerable to exploitation.
+   According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1.
+   
+   The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable    to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.
+   
+   This vulnerability can be exploited using the Evil Printer attack.
+   
+   The suggested VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.
 
-# Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT
+reference:
+   - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
+
 type: CLIENT
-
-author: https://github.com/DakshGajjar
 
 precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:
   - name: SearchRegistryGlob
+    description: Registry path
     default: \HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint\**
-    description: Having NoWarningNoElevationOnInstall set to 1 makes your system vulnerable by design
 
 sources:
-  - query: |
-        SELECT  Name as KeyName,
-                FullPath,
-                Data.type as KeyType, 
-                Data.value as KeyValue,
-                Sys,
-                ModTime as Modified
-        FROM glob(globs=SearchRegistryGlob, accessor='registry')
-        
-        WHERE KeyType = "DWORD"
-        AND KeyName =~ "NoWarningNoElevationOnInstall"
+   - query: |
+         SELECT  Name as KeyName,
+            FullPath,
+            Data.type as KeyType, 
+            Data.value as KeyValue,
+            Sys,
+            ModTime as Modified
+         FROM glob(globs=SearchRegistryGlob, accessor='registry')
+         WHERE KeyType = "DWORD"
+            AND KeyName =~ "NoWarningNoElevationOnInstall"
                   
 column_types:
-  - name: Modified
-    type: timestamp
+   - name: Modified
+   - type: timestamp


### PR DESCRIPTION
According to Microsoft, this vulnerability can only be exploited if the “NoWarningNoElevationOnInstall” key in the registry is set to 1.

The artifact scans the device registry to check if the beforementioned key exists or not; if it is undefined or doesn’t exist, then the system is not vulnerable to the PrintNightmare. Otherwise, the system is considered to be vulnerable to exploitation.

This vulnerability can be exploited using the Evil Printer attack.

The suggested VQL query looks for the registry values to find a registry key named “NoWarningNoElevationOnInstall”.

References:

https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527