### PR TITLE
Update DefenderConfig.yaml

### DIFF
--- a/content/exchange/artifacts/DefenderConfig.yaml
+++ b/content/exchange/artifacts/DefenderConfig.yaml
@@ -12,8 +12,6 @@ description: |
     for a process in exclusions or specific setting name of interest.
     3. ValueRegex - Regex for KeyValue.
     
-    For boolean configuraiton (DWORD): 0=enable, 1=disable
-    
 type: CLIENT
 
 parameters:


### PR DESCRIPTION
removing bad example.

I had copied the details for DisableRealtimeMonitoring which is a confusing example  as true boolean = realtime monitoring is off.