### PR TITLE
Force exchange zip to zero timestamps

### DIFF
--- a/scripts/artifact_reference_index.py
+++ b/scripts/artifact_reference_index.py
@@ -4,7 +4,6 @@ import html
 import yaml
 import re
 import os
-from zipfile import ZipFile
 import argparse
 
 parser = argparse.ArgumentParser(description='Generate artifact documentation.')

--- a/scripts/exchange_index.py
+++ b/scripts/exchange_index.py
@@ -110,7 +110,14 @@ def make_archive(archive_path):
         if not name.endswith(".yaml"):
           continue
 
-        archive.write(os.path.join(root, name))
+        filename = os.path.join(root, name)
+        with open(filename) as fd:
+          data = fd.read()
+
+        # Force archive member to have a fixed timestamp - therefore
+        # the zip hash will depend only on the content, allowing git
+        # to deduplicate it properly across commits.
+        archive.writestr(zipfile.ZipInfo(filename=filename), data)
 
 def make_archive_v1(archive_path):
   with zipfile.ZipFile(archive_path, mode='w',
@@ -124,7 +131,7 @@ def make_archive_v1(archive_path):
         with open(filename) as fd:
           data = fd.read()
 
-        archive.writestr(filename, convert_to_v1(data))
+        archive.writestr(zipfile.ZipInfo(filename=filename), convert_to_v1(data))
 
 # For version 1 we drop all newer fields. This is suitable for older
 # Velociraptor versions which do not support expected_hash or version

--- a/scripts/knowledge_base.py
+++ b/scripts/knowledge_base.py
@@ -3,7 +3,6 @@ import json
 import yaml
 import re
 import os
-from zipfile import ZipFile
 
 # Where we generate the search index.
 commits_url = "https://api.github.com/repos/Velocidex/velociraptor-docs/commits"

--- a/static/exchange/data.json
+++ b/static/exchange/data.json
@@ -2,7 +2,7 @@
     {
         "title": "Windows.Detection.IdatLoader",
         "author": "mgreen27",
-        "description": "This artifact enables running Yara over processes in memory.\nTargeting detection of IDAT Loader.  \n",
+        "description": "This artifact enables running Yara over processes in memory.\nTargeting detection of IDAT Loader and final payloads \nobserved in field.  ",
         "link": "/exchange/artifacts/pages/idatloader",
         "tags": [],
         "author_link": "https://github.com/mgreen27",


### PR DESCRIPTION
We build the exchange zip file on each commit and previously encoded timestamps in the zip - this means each release had a different zip regardless of if the content of the exchange actually changed.

This causes a lot of churn in the repo and also makes it hard to know when the exchange actually changed since the bundle is different on each push.