### PR TITLE
Fixes wrong path variable in Bitsadmin artifact

### DIFF
--- a/content/exchange/artifacts/Bitsadmin.yaml
+++ b/content/exchange/artifacts/Bitsadmin.yaml
@@ -45,7 +45,7 @@ sources:
                 EventData.bytesTotal as bytesTotal,
                 EventData.bytesTransferred as bytesTransferred,
                 EventData.bytesTransferredFromPeer
-            FROM parse_evtx(filename=FullPath)
+            FROM parse_evtx(filename=EventLog)
             WHERE 
                 EventId = 59
                 AND NOT if( condition= UrlWhitelistRegex,

--- a/content/exchange/artifacts/Bitsadmin.yaml
+++ b/content/exchange/artifacts/Bitsadmin.yaml
@@ -45,7 +45,7 @@ sources:
                 EventData.bytesTotal as bytesTotal,
                 EventData.bytesTransferred as bytesTransferred,
                 EventData.bytesTransferredFromPeer
-            FROM parse_evtx(filename=EventLog)
+            FROM parse_evtx(filename=OSPath)
             WHERE 
                 EventId = 59
                 AND NOT if( condition= UrlWhitelistRegex,


### PR DESCRIPTION
FullPath is not defined/part of any surrounding select statement and hence not known to the query. This artifact fails with:

```
ERROR: Symbol FullPath not found. Current Scope is: ...
```