### PR TITLE
Update WS_FTP.yaml

### DIFF
--- a/content/exchange/artifacts/WS_FTP.yaml
+++ b/content/exchange/artifacts/WS_FTP.yaml
@@ -1,3 +1,4 @@
+
 name: Windows.Detection.WS_FTP
 author: Matt Green - @mgreen27
 description: | 
@@ -41,7 +42,7 @@ parameters:
   - name: IocRegex
     type: regex
     description: "IOC Regex in evtxHunt"
-    default: '/AHT/AhtApiService\.asmx|86\.48\.3\.172'
+    default: '/AHT/|86\.48\.3\.172'
   - name: DateAfter
     type: timestamp
     default: 1685232000
@@ -67,7 +68,7 @@ parameters:
             score = 80
       
          strings:
-           $post = /\n.{1,50} \/AHT\/AhtApiService.asmx\/AuthUser.{1,250}\n/
+           $post = /\n.{1,50} POST \/AHT\/{1,250}\n/
            $ip = " 86.48.3.172 " ascii
       
           condition:


### PR DESCRIPTION
Widending logic as any URI that begins with /AHT/ can be used during exploitation