### PR TITLE
Optionally contrain journalctl within a time range

### DIFF
--- a/content/exchange/artifacts/Linux.Sys.JournalCtl.yaml
+++ b/content/exchange/artifacts/Linux.Sys.JournalCtl.yaml
@@ -8,10 +8,22 @@ parameters:
   - name: Length 
     default: 10000
     type: int
-author: Wes Lambert -- @therealwlambert/@weslambert@infosec.exchange 
+  - name: DateBefore
+    type: timestamp
+  - name: DateAfter
+    type: timestamp
+
+author: Wes Lambert -- @therealwlambert/@weslambert@infosec.exchange
 sources:
   - query:
-      LET JCtlOut = SELECT * FROM execve(length=Length, argv=['/usr/bin/journalctl', '-o', 'json'], sep="\n")
+      LET JournalFormat(ts) = format(format='%d-%02d-%02d %02d:%02d:%02d UTC',
+        args=[ts.Year, ts.Month, ts.Day, ts.Hour, ts.Minute, ts.Second])
+      LET DateAfterTime = JournalFormat(ts=if(condition=DateAfter,
+        then=DateAfter, else=timestamp(epoch='1600-01-01')))
+      LET DateBeforeTime = JournalFormat(ts=if(condition=DateBefore,
+        then=DateBefore, else=timestamp(epoch='2200-01-01')))
+      LET JCtlOut = SELECT * FROM execve(length=Length, argv=['/usr/bin/journalctl',
+        '-o', 'json', '-S', DateAfterTime, '-U', DateBeforeTime], sep="\n")
       SELECT
         timestamp(string=ParsedOutput.__REALTIME_TIMESTAMP) AS Timestamp,
         ParsedOutput._HOSTNAME AS _Hostname,


### PR DESCRIPTION
The journal log can be massive. Instead of just limiting the number of rows by number, also allow the user to limit by time, much like with other log artifacts.

Parameter naming and default timestamps are chosen like in similar artifacts.