### PR TITLE
Create Windows.Detection.Network.Changed.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Detection.Network.Changed.yaml
+++ b/content/exchange/artifacts/Windows.Detection.Network.Changed.yaml
@@ -1,0 +1,29 @@
+name: Windows.Detection.Network.Changed
+author: Zane Gittins
+description: |
+   Detects when a new network is added or removed from the system via the NetworkList registry keys.
+
+# Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT
+type: CLIENT_EVENT
+
+
+parameters:
+  - name: Period
+    default: 60
+    type: int64
+    description: The period to check the registry.
+  - name: Globs
+    type: string
+    default: "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkList\\Profiles\\**\\*"
+    description: The registry path to search
+
+
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+
+    query: |
+      SELECT * FROM diff(key="NetworkName", period=Period, query={
+          SELECT Data.value as NetworkName from glob(accessor="reg",globs=Globs) WHERE Name=~"ProfileName" 
+      })


### PR DESCRIPTION
Adds a client monitoring artifact that detects when a network is added/removed in Windows. Particularly useful for tracking new Wireless networks that clients connect to, or when new interfaces are added for common VPN software abused by bad actors.