### PR TITLE
Update PowershellMonitoring.yaml ScriptIgnorePath behavior

### DIFF
--- a/content/exchange/artifacts/PowershellMonitoring.yaml
+++ b/content/exchange/artifacts/PowershellMonitoring.yaml
@@ -132,8 +132,8 @@ sources:
                 AND NOT if(condition=Ignore, then= Payload=~Ignore, else= False)
                 AND NOT if(condition=IgnorePaths,
                     then= EventData.Path =~ ScriptIgnorePath 
-                        OR EventData.ContextInfo.CommandPath =~ ScriptIgnorePath,
-                        OR EventData.ContextInfo.ScriptName =~ ScriptIgnorePath
+                        OR EventData.ContextInfo.CommandPath =~ ScriptIgnorePath
+                        OR EventData.ContextInfo.ScriptName =~ ScriptIgnorePath,
                             else= False)
             LIMIT 1 -- limts to 1 row per IocCsv entry.
         })

--- a/content/exchange/artifacts/PowershellMonitoring.yaml
+++ b/content/exchange/artifacts/PowershellMonitoring.yaml
@@ -133,6 +133,7 @@ sources:
                 AND NOT if(condition=IgnorePaths,
                     then= EventData.Path =~ ScriptIgnorePath 
                         OR EventData.ContextInfo.CommandPath =~ ScriptIgnorePath,
+                        OR EventData.ContextInfo.ScriptName =~ ScriptIgnorePath
                             else= False)
             LIMIT 1 -- limts to 1 row per IocCsv entry.
         })


### PR DESCRIPTION
While helping a team tune out false positives from authorized scripts, we noticed that using the IgnoreScriptPath arg would not work for certain events, because the path to exclude was in the ScriptName field.  So far I've only seen this happen with EID 7937. There's no Path field, and CommandPath is present but empty.