### PR TITLE
Update 'Server.Utills.BackupAzure' to upload to subdirectory

### DIFF
--- a/content/exchange/artifacts/Server.Utils.BackupAzure.yaml
+++ b/content/exchange/artifacts/Server.Utils.BackupAzure.yaml
@@ -1,4 +1,4 @@
-name: Exchange.Server.Utils.BackupAzure
+name: Server.Utils.BackupAzure
 description: |
    This server monitoring artifact will automatically zip and backup
    any collected artifacts to Azure blob storage.

--- a/content/exchange/artifacts/Server.Utils.BackupAzure.yaml
+++ b/content/exchange/artifacts/Server.Utils.BackupAzure.yaml
@@ -1,4 +1,4 @@
-name: Server.Utils.BackupAzure
+name: Exchange.Server.Utils.BackupAzure
 description: |
    This server monitoring artifact will automatically zip and backup
    any collected artifacts to Azure blob storage.
@@ -25,6 +25,11 @@ parameters:
    - name: RemoveDownloads
      type: bool
      description: If set, remove the flow export files after upload
+     
+   - name: UploadSubdirectory
+     default: FALSE
+     type: bool
+     description: If set, upload exports to subirectory per flow
 
 sources:
   - query: |
@@ -38,13 +43,14 @@ sources:
              flow_id=FlowId, wait=TRUE) AS FlowDownload
       FROM watch_monitoring(artifact="System.Flow.Completion")
       WHERE Flow.artifacts_with_results =~ ArtifactNameRegex
-        
+    
       SELECT upload_azure(
       file=FlowDownload,
       accessor="fs",
       sas_url=sas_url,
-      name=format(format="Host %v %v %v.zip",
-                     args=[Fqdn, FlowId, timestamp(epoch=now())])
+      name=if(condition=UploadSubdirectory, 
+                then=format(format="%v/Host %v %v %v.zip",args=[FlowId, Fqdn, FlowId, timestamp(epoch=now())]),
+                else=format(format="Host %v %v %v.zip",args=[Fqdn, FlowId, timestamp(epoch=now())]))
       ) AS Upload
 
       FROM completions


### PR DESCRIPTION
Currently all data is uploaded to the Azure Blob Storage in the same directory. However, if you run multiple hunts and let all of them upload this becomes a big mess. This PR allows you to upload everything into a sub-directory per flow, bundling the results of all hosts from the same hunt/flow in the same subdirectory.