### PR TITLE
Update Windows.EventLogs.Hayabusa.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -12,10 +12,10 @@ description: |
 author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity
 
 tools:
- - name: Hayabusa-2.11.0
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.11.0/hayabusa-2.11.0-win-64-bit.zip
-   expected_hash: 79847e15f14f8bda738f3b6dbca03bd2b742f09f11c129b75941fe6f3ec8c164
-   version: 2.11.0
+ - name: Hayabusa-2.12.0
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.12.0/hayabusa-2.12.0-windows-64-bit.zip
+   expected_hash: 24b3cc66902708dbe9543efaeb8ffa77ced6b0d29cfc5c92bf10fd8e8b04e24a
+   version: 2.12.0
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -88,6 +88,7 @@ sources:
         -- Build the command line considering all options
         LET cmdline <= filter(list=(
           HayabusaExe, "csv-timeline", "--live-analysis",
+          "--no-wizard", 
           "--output", CSVFile,
           "--min-level", MinimalLevel,
           "--profile", OutputProfile,


### PR DESCRIPTION
Hello, I'm a member of [YamatoSecurity](https://github.com/Yamato-Security) and one of the developers of [Hayabusa](https://github.com/Yamato-Security/hayabusa).
Thank you so much for adding our tools to Artifact :)

The [scan wizard](https://github.com/Yamato-Security/hayabusa?tab=readme-ov-file#scan-wizard) features have been introduced from version `2.11.0`.
Because of this feature, Artifact will fail without the `--no-wizard` option, so I added the `--no-wizard` option.

Our team also released version [2.12.0](https://github.com/Yamato-Security/hayabusa/releases/tag/v2.12.0) in December. So I updated version in this PR.

Thanks again such a great project.