### PR TITLE
feat: add json output option in Windows.EventLogs.Hayabusa 

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -5,9 +5,9 @@ description: |
    hunting tool.
 
    This artifact runs Hayabusa on the endpoint against the specified
-   Windows event log directory, and generates and uploads a single CSV
+   Windows event log directory, and generates and uploads a single CSV/JSON
    file for further analysis with excel, timeline explorer, elastic
-   stack, etc.
+   stack, jq, etc.
 
 author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity
 
@@ -32,6 +32,13 @@ parameters:
    description: "Enable rules marked as noisy"
    type: bool
    default: N
+ - name: OutputFormat
+   description: "Choose the format of the result file"
+   default: csv
+   type: choices
+   choices:
+     - csv
+     - json
  - name: OutputProfile
    description: "Decide how much data you want back"
    default: standard
@@ -83,17 +90,19 @@ sources:
         LET _ <= if(condition=UpdateRules, then={
         SELECT * FROM execve(argv=['cmd.exe', '/c', 'cd', TmpDir, '&', HayabusaExe, 'update-rules']) })
 
-        LET CSVFile <= TmpDir + '\\hayabusa_results.csv'
+        LET HayabusaCmd <= OutputFormat + '-timeline'
+        LET ResultFile <= TmpDir + '\\hayabusa_results.' + OutputFormat
 
         -- Build the command line considering all options
         LET cmdline <= filter(list=(
-          HayabusaExe, "csv-timeline", "--live-analysis",
+          HayabusaExe, HayabusaCmd, "--live-analysis",
           "--no-wizard", 
-          "--output", CSVFile,
+          "--output", ResultFile,
           "--min-level", MinimalLevel,
           "--profile", OutputProfile,
           "--quiet", "--no-summary",
           "--threads", str(str=Threads),
+          if(condition= OutputFormat = "json", then="-L"),
           if(condition=UTC, then="--UTC"),
           if(condition=NoisyRules, then="--enable-noisy-rules"),
           if(condition=EIDFilter, then="--eid-filter")
@@ -105,9 +114,12 @@ sources:
         WHERE log(message=Stdout)
 
         -- Upload the raw file.
-        SELECT upload(file=CSVFile) AS Uploads FROM scope()
+        SELECT upload(file=ResultFile) AS Uploads FROM scope()
 
  - name: Results
    query: |
+        LET CSV_RESULT  <= SELECT * FROM parse_csv(filename=ResultFile)
+        LET JSON_RESULT <= SELECT * FROM parse_jsonl(filename=ResultFile)
+        
         SELECT *, timestamp(string=Timestamp) AS EventTime
-        FROM parse_csv(filename=CSVFile)
+        FROM if(condition= OutputFormat = "csv", then=CSV_RESULT, else=JSON_RESULT)

--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -94,7 +94,7 @@ sources:
         LET ResultFile <= TmpDir + '\\hayabusa_results.' + OutputFormat
 
         -- Build the command line considering all options
-        LET cmdline <= filter(list=(
+        LET cmdline <= (
           HayabusaExe, HayabusaCmd, "--live-analysis",
           "--no-wizard", 
           "--output", ResultFile,
@@ -106,7 +106,7 @@ sources:
           if(condition=UTC, then="--UTC"),
           if(condition=NoisyRules, then="--enable-noisy-rules"),
           if(condition=EIDFilter, then="--eid-filter")
-        ),  regex=".+")
+        )
 
         -- Run the tool and divert messages to logs.
         LET ExecHB <= SELECT *
@@ -118,8 +118,8 @@ sources:
 
  - name: Results
    query: |
-        LET CSV_RESULT  <= SELECT * FROM parse_csv(filename=ResultFile)
-        LET JSON_RESULT <= SELECT * FROM parse_jsonl(filename=ResultFile)
+        LET CSV_RESULT  = SELECT * FROM parse_csv(filename=ResultFile)
+        LET JSON_RESULT = SELECT * FROM parse_jsonl(filename=ResultFile)
         
         SELECT *, timestamp(string=Timestamp) AS EventTime
         FROM if(condition= OutputFormat = "csv", then=CSV_RESULT, else=JSON_RESULT)


### PR DESCRIPTION
Hello, Thank you so much for maintaining tools :)


### What changed in this PR

`Hayabusa` has a `json-timeline` command as shown in the [README](https://github.com/Yamato-Security/hayabusa?tab=readme-ov-file#json-timeline-command). 
When analyzing `Haybausa`'s output results using `ELK Stack`,`Splunk` etc..., you can obtain more detailed fields with `JSON` than with `CSV`. For that purpose, I have added a `JSON` output option.

### Added JSON output format option 
![json-option](https://github.com/Velocidex/velociraptor-docs/assets/41001169/94cf2b20-8dd7-4107-9e06-4507813c8ae6)

### JSON output result image
![result-json2](https://github.com/Velocidex/velociraptor-docs/assets/41001169/27c64893-9cb3-44fb-bb0b-46ac261f2abc)
![result-json](https://github.com/Velocidex/velociraptor-docs/assets/41001169/13b2e9fa-9ffe-4056-b137-4d1dc7ebaba2)
![hayabusa-json](https://github.com/Velocidex/velociraptor-docs/assets/41001169/a062d8df-7906-42d2-9094-b1aed576db23)

I have confirmed that the original CSV option is also working properly.

Thank you for your time.
Best,