### PR TITLE
Fix: argument Null error in Exchange.Windows.EventLogs.Hayabusa

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -94,7 +94,7 @@ sources:
         LET ResultFile <= TmpDir + '\\hayabusa_results.' + OutputFormat
 
         -- Build the command line considering all options
-        LET cmdline <= (
+        LET cmdline <= filter(list=(
           HayabusaExe, HayabusaCmd, "--live-analysis",
           "--no-wizard", 
           "--output", ResultFile,
@@ -106,7 +106,7 @@ sources:
           if(condition=UTC, then="--UTC"),
           if(condition=NoisyRules, then="--enable-noisy-rules"),
           if(condition=EIDFilter, then="--eid-filter")
-        )
+        ), regex=".+")
 
         -- Run the tool and divert messages to logs.
         LET ExecHB <= SELECT *


### PR DESCRIPTION
Sorry for my lack of confirmation ... 
https://github.com/Velocidex/velociraptor-docs/pull/774/commits/3671ca50fc9b8665dab68291807a21a2857d8d88 commit caused a following Hayabusa command line error, so I fixed it.

```
2024-01-28T23:54:03Z		
shell: Running external command [C:\Users\admin\AppData\Local\Temp\gui_datastore\temp\tmp2945452154\hayabusa-2.12.0-win-x64.exe csv-timeline --live-analysis --no-wizard --output C:\Users\admin\AppData\Local\Temp\gui_datastore\temp\tmp2945452154\hayabusa_results.csv --min-level informational --profile standard --quiet --no-summary --threads 2 Null --UTC Null Null]
2024-01-28T23:54:03Z		
error: unexpected argument 'Null' found
```
The following filter was needed to filter Null when if(condition) is False.
https://github.com/Velocidex/velociraptor-docs/compare/master...fukusuket:velociraptor-docs:fix-hayabusa-artifact-nil-error?expand=1#diff-c34530120068a449fa566d79550de2caf5a5feb479b8392473a0b18ac20ea8a6R97

I have confirmed that the CSV/JSON option is also working properly.
