### PR TITLE
Update Windows.EventLogs.Hayabusa.yaml(added filter options)

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -5,7 +5,7 @@ description: |
    hunting tool.
 
    This artifact runs Hayabusa on the endpoint against the specified
-   Windows event log directory, and generates and uploads a single CSV/JSON
+   Windows event log directory, and generates and uploads a single CSV/JSONL
    file for further analysis with excel, timeline explorer, elastic
    stack, jq, etc.
 
@@ -38,7 +38,7 @@ parameters:
    type: choices
    choices:
      - csv
-     - json
+     - jsonl
  - name: OutputProfile
    description: "Decide how much data you want back"
    default: standard
@@ -70,6 +70,26 @@ parameters:
    description: "Number of threads"
    type: int
    default: 2
+ - name: TimelineOffset
+   description: "Scan recent events based on an offset (ex: 1y, 3M, 30d, 24h, 30m)"
+ - name: TimelineStart
+   description: "Start time of the event logs to load (ex: '2020-02-22 00:00:00 +09:00')"
+ - name: TimelineEnd
+   description: "End time of the event logs to load (ex: '2022-02-22 23:59:59 +09:00')"
+ - name: ExcludeCategory
+   description: "Do not load rules with specified logsource categories (ex: process_creation,pipe_created)"
+ - name: ExcludeEID
+   description: "Do not scan specific EIDs for faster speed (ex: 1) (ex: 1,4688)"
+ - name: ExcludeStatus
+   description: "Do not load rules according to status (ex: experimental) (ex: stable,test)"
+ - name: ExcludeTag
+   description: "Do not load rules with specific tags (ex: sysmon)"
+ - name: IncludeCategory
+   description: "Only load rules with specified logsource categories (ex: process_creation,pipe_created)"
+ - name: IncludeEID
+   description: "Scan only specified EIDs for faster speed (ex: 1) (ex: 1,4688)"
+ - name: IncludeTag
+   description: "Only load rules with specific tags (ex: attack.execution,attack.discovery)"
 
 sources:
  - name: Upload
@@ -90,10 +110,11 @@ sources:
         LET _ <= if(condition=UpdateRules, then={
         SELECT * FROM execve(argv=['cmd.exe', '/c', 'cd', TmpDir, '&', HayabusaExe, 'update-rules']) })
 
-        LET HayabusaCmd <= OutputFormat + '-timeline'
+        LET HayabusaCmd <= if(condition=OutputFormat = "csv", then="csv-timeline", else="json-timeline")
         LET ResultFile <= TmpDir + '\\hayabusa_results.' + OutputFormat
 
         -- Build the command line considering all options
+        -- If it does not match if(condition...), it returns Null, so remove Null with filter(....regex=".+")
         LET cmdline <= filter(list=(
           HayabusaExe, HayabusaCmd, "--live-analysis",
           "--no-wizard", 
@@ -102,10 +123,20 @@ sources:
           "--profile", OutputProfile,
           "--quiet", "--no-summary",
           "--threads", str(str=Threads),
-          if(condition= OutputFormat = "json", then="-L"),
+          if(condition=OutputFormat = "jsonl", then="-L"),
           if(condition=UTC, then="--UTC"),
           if(condition=NoisyRules, then="--enable-noisy-rules"),
-          if(condition=EIDFilter, then="--eid-filter")
+          if(condition=EIDFilter, then="--eid-filter"),
+          if(condition=TimelineOffset, then="--timeline-offset"),   if(condition=TimelineOffset, then=TimelineOffset),
+          if(condition=TimelineStart, then="--timeline-start"),     if(condition=TimelineStart, then=TimelineStart),
+          if(condition=TimelineEnd, then="--timeline-end"),         if(condition=TimelineEnd, then=TimelineEnd),
+          if(condition=ExcludeCategory, then="--exclude-category"), if(condition=ExcludeCategory, then=ExcludeCategory),
+          if(condition=ExcludeEID, then="--exclude-eid"),           if(condition=ExcludeEID, then=ExcludeEID),
+          if(condition=ExcludeStatus, then="--exclude-status"),     if(condition=ExcludeStatus, then=ExcludeStatus),
+          if(condition=ExcludeTag, then="--exclude-tag"),           if(condition=ExcludeTag, then=ExcludeTag),
+          if(condition=IncludeCategory, then="--include-category"), if(condition=IncludeCategory, then=IncludeCategory),
+          if(condition=IncludeEID, then="--include-eid"),           if(condition=IncludeEID, then=IncludeEID),
+          if(condition=IncludeTag, then="--include-tag"),           if(condition=IncludeTag, then=IncludeTag),
         ), regex=".+")
 
         -- Run the tool and divert messages to logs.
@@ -119,7 +150,7 @@ sources:
  - name: Results
    query: |
         LET CSV_RESULT  = SELECT * FROM parse_csv(filename=ResultFile)
-        LET JSON_RESULT = SELECT * FROM parse_jsonl(filename=ResultFile)
+        LET JSONL_RESULT = SELECT * FROM parse_jsonl(filename=ResultFile)
         
         SELECT *, timestamp(string=Timestamp) AS EventTime
-        FROM if(condition= OutputFormat = "csv", then=CSV_RESULT, else=JSON_RESULT)
+        FROM if(condition= OutputFormat = "csv", then=CSV_RESULT, else=JSONL_RESULT)


### PR DESCRIPTION
Along with [adding comments](https://github.com/Velocidex/velociraptor-docs/pull/775#issuecomment-1913793477), I've added filter options to speed things up. 

### What Changed
- Changed json -> jsonl
- Added comment about the need for filter function
  - https://github.com/Velocidex/velociraptor-docs/pull/775#issuecomment-1913793477
- Added hayabusa filter options
  - Added csv-timeline/json-timeline filter options for faster scanning
    - https://github.com/Yamato-Security/hayabusa?tab=readme-ov-file#csv-timeline-command

![hayabusa-filter](https://github.com/Velocidex/velociraptor-docs/assets/41001169/6d5e6f0b-3ea9-46c1-903c-e8f4cd029850)

I have confirmed that CSV/JSONL default option(and each option) working properly.

Thank you for your time.
Best,