### PR TITLE
Create Linux.Apache.AccessLog.yaml

### DIFF
--- a/content/exchange/artifacts/Linux.Apache.AccessLog.yaml
+++ b/content/exchange/artifacts/Linux.Apache.AccessLog.yaml
@@ -1,0 +1,39 @@
+name: Linux.Apache.AccessLogs
+
+description: |
+  Parses Apache access logs on a Linux machine to extract detailed request information.
+
+author: Krishna Patel, Harsh Jaroli
+
+reference:
+  - https://httpd.apache.org/docs/2.4/logs.html
+
+type: CLIENT
+
+parameters:
+  - name: AccessLogPath
+    default: /var/log/apache2/access.log*  # Adjusted for typical Linux Apache log paths
+
+  - name: ApacheAccessLogGrok
+    description: A Grok expression for parsing Apache access log lines.
+    default: >-
+      %{IPORHOST:client} - - \[%{HTTPDATE:timestamp}\] "%{WORD:method} %{URIPATHPARAM:request} HTTP/%{NUMBER:httpversion}" %{NUMBER:status} %{NUMBER:response_size}
+
+sources:
+  - query: |
+      // Basic Apache access log parsing via GROK expressions.
+      SELECT timestamp(string=Event.timestamp) AS Time,
+             Event.client AS ClientIP,
+             Event.method AS RequestMethod,
+             Event.request AS RequestURL,
+             Event.httpversion AS HTTPVersion,
+             Event.status AS ResponseStatus,
+             Event.response_size AS ResponseSize,
+             OSPath
+        FROM foreach(
+          row={
+              SELECT OSPath FROM glob(globs=AccessLogPath)  # Uses glob to match log file patterns
+          }, query={
+              SELECT grok(grok=ApacheAccessLogGrok, data=Line) AS Event, OSPath
+              FROM parse_lines(filename=OSPath)  # Parses each line of the logs using the defined Grok pattern
+          })

--- a/content/exchange/artifacts/Linux.Apache.AccessLog.yaml
+++ b/content/exchange/artifacts/Linux.Apache.AccessLog.yaml
@@ -12,7 +12,7 @@ type: CLIENT
 
 parameters:
   - name: AccessLogPath
-    default: /var/log/apache2/access.log*  # Adjusted for typical Linux Apache log paths
+    default: /var/log/apache2/access.log*  
 
   - name: ApacheAccessLogGrok
     description: A Grok expression for parsing Apache access log lines.

--- a/content/exchange/artifacts/Linux.Apache.AccessLog.yaml
+++ b/content/exchange/artifacts/Linux.Apache.AccessLog.yaml
@@ -12,7 +12,7 @@ type: CLIENT
 
 parameters:
   - name: AccessLogPath
-    default: /var/log/apache2/access.log*  
+    default: /var/log/apache2/access.log* 
 
   - name: ApacheAccessLogGrok
     description: A Grok expression for parsing Apache access log lines.
@@ -21,8 +21,8 @@ parameters:
 
 sources:
   - query: |
-      // Basic Apache access log parsing via GROK expressions.
-      SELECT timestamp(string=Event.timestamp) AS Time,
+      
+      SELECT timestamp(string=Event.timestamp) AS TIME
              Event.client AS ClientIP,
              Event.method AS RequestMethod,
              Event.request AS RequestURL,
@@ -32,8 +32,8 @@ sources:
              OSPath
         FROM foreach(
           row={
-              SELECT OSPath FROM glob(globs=AccessLogPath)  # Uses glob to match log file patterns
+              SELECT OSPath FROM glob(globs=AccessLogPath) 
           }, query={
               SELECT grok(grok=ApacheAccessLogGrok, data=Line) AS Event, OSPath
-              FROM parse_lines(filename=OSPath)  # Parses each line of the logs using the defined Grok pattern
+              FROM parse_lines(filename=OSPath)
           })


### PR DESCRIPTION
Parses access logs on a Linux machine to extract required information.

- It uses the GROK expression to parse the logs.