### PR TITLE
Fixed Hayabusa artifact(Change to package not detected by Defender)

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -13,8 +13,8 @@ author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Math
 
 tools:
  - name: Hayabusa-2.15.0
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.15.0/hayabusa-2.15.0-win-x64.zip
-   expected_hash: 158b404fa5fd6937a1331ed1acde262998e6e1586a8604346956d4fc6a14b5d6
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.15.0/hayabusa-2.15.0-win-x64-r2.zip
+   expected_hash: c8c40c03713688bdaf4ba1688e7ce7ec3eb06231906ad09e7d33f207c15a2ab9
    version: 2.15.0
 
 precondition: SELECT OS From info() where OS = 'windows'


### PR DESCRIPTION
Changed to Hayabusa package which is not detected by Defender.
- https://github.com/Yamato-Security/hayabusa/issues/1356#issuecomment-2148631803

@scudette 
Thank you so much  for the issue report and suggestions :)
