### PR TITLE
Update and rename Windows.Apache.AccessLogs.yaml to Apache.AccessLogs.yaml

### DIFF
--- a/content/exchange/artifacts/Apache.AccessLogs.yaml
+++ b/content/exchange/artifacts/Apache.AccessLogs.yaml
@@ -1,4 +1,4 @@
-name: Windows.Apache.AccessLogs
+name: Apache.AccessLogs
 
 description: |
   Parses Apache access logs to extract detailed request information.

--- a/content/exchange/artifacts/Apache.AccessLogs.yaml
+++ b/content/exchange/artifacts/Apache.AccessLogs.yaml
@@ -1,4 +1,4 @@
-name: Apache.AccessLogs
+name: Generic.Apache.AccessLogs
 
 description: |
   Parses Apache access logs to extract detailed request information.
@@ -12,7 +12,7 @@ type: CLIENT
 
 parameters:
   - name: AccessLogPath
-    default: C:/Apache/logs/access.log*
+    default: /{/var/log/httpd,/var/log/apache2,C:/Apache/logs}/{access.log,access_log}*
 
   - name: ApacheAccessLogGrok
     description: A Grok expression for parsing Apache access log lines.


### PR DESCRIPTION
With this change I removed the precondition for windows. So now this same artifact will work on linux as well. 
This change is added because of the suggestion added [here](https://github.com/Velocidex/velociraptor-docs/pull/835#issuecomment-2084364485)