### PR TITLE
Fix for Trawler artifact not being called properly

### DIFF
--- a/content/exchange/artifacts/Trawler.yaml
+++ b/content/exchange/artifacts/Trawler.yaml
@@ -39,7 +39,7 @@ sources:
        LET TrawlerOutputPath = '"' + TrawlerOutput.Path + '"'
 
        LET cmdline <= join(
-           array=['.\\trawler.ps1', '-outpath', TrawlerOutputPath],
+           array=[TrawlerLocation, '-outpath', TrawlerOutputPath],
            sep=' ')
 
        LET _ <= SELECT *


### PR DESCRIPTION
Previously it would call %temp%\trawler.ps1 which wouldn't run, Trawler exists at %temp%\TmpDir\trawler.ps1, so this commit fixes that behavior.