### PR TITLE
Bump Windows.EventLogs.Chainsaw.yaml version to fix issues seen durin…

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Chainsaw.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Chainsaw.yaml
@@ -18,10 +18,10 @@ description: |
 author: Wes Lambert - @therealwlambert, James Dorgan - @FranticTyping, Alex Korntizer - @AlexKornitzer
 tools:
   - name: Chainsaw
-    url: https://github.com/WithSecureLabs/chainsaw/releases/download/v2.7.2/chainsaw_all_platforms+rules+examples.zip
-    version: 2.7.2
-    expected_hash: 4a9c501af2c8d67522cc80a58ca1ecb3adb97e105a3ad53e419a115a52f2ae6e
-    
+    url: https://github.com/WithSecureLabs/chainsaw/releases/download/v2.9.0/chainsaw_all_platforms+rules+examples.zip
+    version: 2.9.0
+    expected_hash: 9F809EA14B71E7C53FDE8EBEF7F3A82881F4DCACEC97566B29CC914324667EDA
+     
 precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:


### PR DESCRIPTION
…g Windows 11

Previously Chainsaw would hang during execution (not related to Velociraptor), and it was identified as an issue with 2.7.2 on Windows 10 and 11, these issues appear to have been resolved with 2.9.0