### PR TITLE
Update VQL Reference for glob() function.

### DIFF
--- a/content/vql_reference/plugin/glob/_index.md
+++ b/content/vql_reference/plugin/glob/_index.md
@@ -112,7 +112,5 @@ files in all directories other than /proc, /sys or /snap
 
 ```vql
 SELECT * FROM glob(globs='/**/*.pem',
-    recursion_callback="x=>NOT x.Name =~ '^/(proc|sys|snap)'")
+    recursion_callback="x=>NOT x.Name =~ '^(proc|sys|snap)'")
 ```
-
-


### PR DESCRIPTION
Update recursion_callback example to filter correctly when used with `Name` column instead of `FullPath` by removing regex for leading `/` which is not in that column.