### PR TITLE
Add artifacts to monitor network communication on clients

### DIFF
--- a/content/exchange/artifacts/Generic.Events.TrackNetworkConnections.yaml
+++ b/content/exchange/artifacts/Generic.Events.TrackNetworkConnections.yaml
@@ -1,0 +1,24 @@
+name: Generic.Events.TrackNetworkConnections
+author: Herbert Bärschneider @SEC Consult
+description: |
+   This artifact is meant for monitoring network connections on clients.
+   It periodically queries the existing network connections and emits lines for differences (new connections and missing/removed ones).
+   Network connections are tracked and compared based on following elements: process id, layer 3 protocol, layer 4 protocol, local address used, local port used, remote address used, remote port used.
+   
+   The network connection information is enriched with process information to make it easier to analyze emited lines.
+
+type: CLIENT_EVENT
+
+parameters:
+   - name: Period
+     default: 2
+     type: int
+     description: how many seconds the artifact waits between checking network connections for changes
+
+sources:
+    - query: |
+        LET NetworkConnections = SELECT *, format(format="%v %v %v %v %v %v %v", args=[Pid, Family, Type, Laddr.IP, Laddr.Port, Raddr.IP, Raddr.Port]) AS DiffKey FROM netstat()
+      
+        LET EventQuery = SELECT * FROM diff(query=NetworkConnections, period=Period, key="DiffKey")
+      
+        SELECT *, process_tracker_get(id=Pid) AS ProcInfo FROM EventQuery

--- a/content/exchange/artifacts/Server.Alerts.TrackNetworkConnections.yaml
+++ b/content/exchange/artifacts/Server.Alerts.TrackNetworkConnections.yaml
@@ -30,7 +30,7 @@ sources:
     - query: |
         SELECT * FROM foreach(
           row={
-            SELECT *, client_info(client_id=ClientId).os_info.fqdn AS Fqdn from watch_monitoring(artifact='SEC.N01_Preparation.TrackNetworkConnections')
+            SELECT *, client_info(client_id=ClientId).os_info.fqdn AS Fqdn from watch_monitoring(artifact='Exchange.Generic.Events.TrackNetworkConnections')
             WHERE Fqdn =~ ClientRegex AND ProcInfo.Data.Name =~ ProcessNameRegex AND Raddr.IP =~ RemoteIpRegex AND format(format="%v", args=Raddr.Port) =~ RemotePortRegex
               AND Diff =~ "added"
           },

--- a/content/exchange/artifacts/Server.Alerts.TrackNetworkConnections.yaml
+++ b/content/exchange/artifacts/Server.Alerts.TrackNetworkConnections.yaml
@@ -1,0 +1,46 @@
+name: Server.Alerts.TrackNetworkConnections
+author: Herbert Bärschneider @SEC Consult
+description: |
+   This artifact alerts on network connections tracked by Velociraptor on clients.
+   Requires the client_event artifact 'SEC.N01_Preparation.TrackNetworkConnections' to be enabled.
+   
+   You can filter alerts based on FQDN of the client, process name, remote ip and remote port.
+   Only created network connections are alerted on (meaning you don't get an alert when the system removes the connection).
+   You should use those filters, else there be spam to be had :D
+
+type: SERVER_EVENT
+
+parameters:
+  - name: WebHook
+    description: The token URL obtained from Slack/Teams/Discord (or basicly any communication-service that supports webhooks). Leave blank to use server metadata. e.g. https://hooks.slack.com/services/XXXX/YYYY/ZZZZ
+  - name: ClientRegex
+    type: regex
+    description: Regex for filtering on the client fqdn name
+  - name: ProcessNameRegex
+    type: regex
+    description: Regex for filtering on the process name - does not cover full path of the process image
+  - name: RemoteIpRegex
+    type: regex
+    description: Regex for filtering on the remote ip connected to
+  - name: RemotePortRegex
+    type: regex
+    description: Regex for filtering on the remote port connected to
+
+sources:
+    - query: |
+        SELECT * FROM foreach(
+          row={
+            SELECT *, client_info(client_id=ClientId).os_info.fqdn AS Fqdn from watch_monitoring(artifact='SEC.N01_Preparation.TrackNetworkConnections')
+            WHERE Fqdn =~ ClientRegex AND ProcInfo.Data.Name =~ ProcessNameRegex AND Raddr.IP =~ RemoteIpRegex AND format(format="%v", args=Raddr.Port) =~ RemotePortRegex
+              AND Diff =~ "added"
+          },
+          query={
+            SELECT * FROM http_client(
+            data=serialize(item=dict(
+                text=format(format="client %v has process %v communicate to remote ip %v on remote port %v",
+                            args=[Fqdn, ProcInfo.Data.Name, Raddr.IP, Raddr.Port])),
+                format="json"),
+            headers=dict(`Content-Type`="application/json"),
+            method="POST",
+            url=WebHook)
+        })

--- a/content/exchange/artifacts/Server.Alerts.TrackNetworkConnections.yaml
+++ b/content/exchange/artifacts/Server.Alerts.TrackNetworkConnections.yaml
@@ -2,7 +2,7 @@ name: Server.Alerts.TrackNetworkConnections
 author: Herbert Bärschneider @SEC Consult
 description: |
    This artifact alerts on network connections tracked by Velociraptor on clients.
-   Requires the client_event artifact 'SEC.N01_Preparation.TrackNetworkConnections' to be enabled.
+   Requires the client_event artifact 'Generic.Events.TrackNetworkConnections' to be enabled.
    
    You can filter alerts based on FQDN of the client, process name, remote ip and remote port.
    Only created network connections are alerted on (meaning you don't get an alert when the system removes the connection).


### PR DESCRIPTION
Hi all,

we created artifacts to complement Process Tracking for Windows with network connection tracking.
The artifact was tested on Windows and Linux. Due to using built-in functions only, it should work on all supported OSs.

network connections are tracked by periodically diffing the netstat info. Added or removed connections are identified by combining Pid, layer 3 protocol, layer 4 protocol, local address used, local port used, remote address used, remote address used. Based on the PID, network information is enriched with process information.

The client monitoring is complemented with a server alerting artifact. That artifact allows sending messages via webhook about the tracked network connections. Connections can be filtered on the client that emitted the connection, the name of the process that started the network connection, the remote ip being contacted and the remote port being contacted. Those filters should also be used, as it is easy to spam the webhook (lots of network activity by default :D)

There will be a blog post by SEC Consult soon about our though process behind creating these artifacts and some recommendations based on our tests.

I wish the community much fun with this contribution. :)
