### PR TITLE
Linux.Applications.Docker.Ps

### DIFF
--- a/content/exchange/artifacts/Linux.Applications.Docker.Ps.yaml
+++ b/content/exchange/artifacts/Linux.Applications.Docker.Ps.yaml
@@ -1,0 +1,34 @@
+name: Linux.Applications.Docker.Ps
+author: Ján Trenčanský - j91321@infosec.exchange
+description: Get Docker containers by connecting to the docker.socket. Same as running `docker ps`
+reference:
+  - https://docs.docker.com/engine/api/v1.45/#tag/Container/operation/ContainerList
+
+parameters:
+  - name: dockerSocket
+    description: |
+      Docker server socket. You will normally need to be root to connect.
+    default: /var/run/docker.sock
+  - name: all
+    description: |
+        Show non-running containers. Equals to `docker ps -a`.
+    type: bool
+    default: N
+sources:
+  - precondition: |
+      SELECT OS From info() where OS = 'linux'
+    query: |
+        LET running_containers = SELECT parse_json_array(data=Content) as JSON FROM http_client(url=dockerSocket + ":unix/containers/json")
+        LET all_containers = SELECT parse_json_array(data=Content) as JSON FROM http_client(url=dockerSocket + ":unix/containers/json", params=dict(all=True))
+        SELECT * FROM foreach(
+            row={
+                SELECT * FROM if(
+                    condition=all,
+                    then=all_containers,
+                    else=running_containers
+                )
+            },
+            query={
+                SELECT * FROM JSON
+            }
+        )


### PR DESCRIPTION
Uses Docker socket to get basic listing of containers. Equivalent of commands `docker ps` and `docker ps -a`. Useful when working within environments with many dockerized applications.