### PR TITLE
Add nethogs artifact monitoring bandwidth per process on Linux

### DIFF
--- a/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
@@ -1,0 +1,57 @@
+name: Linux.Event.Network.Nethogs
+author: 'Andreas Misje - @misje'
+type: CLIENT_EVENT
+description: |
+  Monitor network bandwidth per process, using "nethogs". This artifact will
+  list all processes that produces (non-local) network traffic on the client,
+  leveraging the process tracker, and displays the total bytes received and sent
+  in the given time frame.
+  
+  Note that the tool/package "nethogs" needs to be installed before calling this
+  artifact.
+    
+precondition:
+  SELECT * FROM info() where OS = 'linux'
+
+sources:
+    - query: |
+       LET Hoggers = SELECT Process,
+                            PID,
+                            UID,
+                            Sent,
+                            Recv
+         FROM foreach(
+           row={
+             SELECT *
+             FROM execve(argv=['/usr/sbin/nethogs', '-t'],
+                         length=10000,
+                         sep='\n\nRefreshing:\n')
+           },
+           query={
+             SELECT timestamp(epoch=now()) AS Timestamp,
+                    *
+             FROM parse_records_with_regex(
+               accessor='data',
+               file=Stdout,
+               regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>\d+\.\d+|0)\t(?P<Recv>\d+\.\d+|0)''')
+           })
+       SELECT *
+       FROM foreach(
+         row={
+           SELECT *
+           FROM Hoggers
+         },
+         query={
+           SELECT 
+                  Pid,
+                  Name,
+                  CommandLine,
+                  Cwd,
+                  Username,
+                  StartTime,
+                  EndTime,
+                  Sent,
+                  Recv
+           FROM process_tracker_pslist()
+           WHERE Pid = PID
+         })

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -1,0 +1,77 @@
+name: Linux.Network.Nethogs
+author: 'Andreas Misje - @misje'
+description: |
+  Monitor network bandwidth per process, using "nethogs". This artifact will
+  list all processes that produces (non-local) network traffic on the client,
+  leveraging the process tracker, and displays the total bytes received and sent
+  in the given time frame.
+  
+  Note that the tool/package "nethogs" needs to be installed before calling this
+  artifact.
+
+parameters:
+  - name: Duration
+    type: integer
+    description: Number of seconds to monitor processes
+    default: 300
+    
+precondition:
+  SELECT * FROM info() where OS = 'linux'
+
+sources:
+    - query: |
+       LET Hoggers <= SELECT Process,
+                             PID,
+                             UID,
+                             humanize(bytes=parse_float(string=Sent) * 1024) AS Sent,
+                             humanize(
+                               bytes=parse_float(
+                                 string=Recv) * 1024) AS Recv
+         FROM query(
+           timeout=Duration,
+           query={
+             SELECT 
+                    Process,
+                    PID,
+                    UID,
+                    Sent,
+                    Recv
+             FROM foreach(
+               row={
+                 SELECT *
+                 FROM execve(argv=['nethogs', '-v', '1', '-t'],
+                             length=10000,
+                             sep='\n\nRefreshing:\n')
+               },
+               query={
+                 SELECT 
+                        Timestamp,
+                        *
+                 FROM parse_records_with_regex(
+                   accessor='data',
+                   file=Stdout,
+                   regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>\d+\.\d+|0)\t(?P<Recv>\d+\.\d+|0)''')
+               })
+           })
+         GROUP BY Process
+
+       SELECT *
+       FROM foreach(
+         row={
+           SELECT *
+           FROM Hoggers
+         },
+         query={
+           SELECT 
+                  Pid,
+                  Name,
+                  CommandLine,
+                  Cwd,
+                  Username,
+                  StartTime,
+                  EndTime,
+                  Sent,
+                  Recv
+           FROM process_tracker_pslist()
+           WHERE Pid = PID
+         })

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -39,7 +39,7 @@ sources:
              FROM foreach(
                row={
                  SELECT *
-                 FROM execve(argv=['nethogs', '-v', '1', '-t'],
+                 FROM execve(argv=['/usr/sbin/nethogs', '-v', '1', '-t'],
                              length=10000,
                              sep='\n\nRefreshing:\n')
                },

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -44,9 +44,7 @@ sources:
                              sep='\n\nRefreshing:\n')
                },
                query={
-                 SELECT 
-                        Timestamp,
-                        *
+                 SELECT *
                  FROM parse_records_with_regex(
                    accessor='data',
                    file=Stdout,


### PR DESCRIPTION
In order to detect a process by its bandwidth usage, nethogs is an excellent tool. This artifact runs nethogs for a given period of time and reports the results.