### PR TITLE
Fix Notebooks.Admin.Flows artifact

### DIFF
--- a/content/exchange/artifacts/Notebooks.Admin.Flows.yaml
+++ b/content/exchange/artifacts/Notebooks.Admin.Flows.yaml
@@ -1,4 +1,4 @@
-﻿name: Notebooks.Admin.Flows
+name: Notebooks.Admin.Flows
 author: Andreas Misje – @misje
 description: |
   This notebooks lists all recent flows/collections across all orgs on the


### PR DESCRIPTION
Something weird in the original version is causing [this part of the code](https://github.com/Velocidex/velociraptor/blob/b4e45a3a4b09268a877c6270b16c0ec95884bbe3/services/repository/manager.go#L190) to trigger, which means that artifact_set() fails.

All I did in this change is to create a new yaml file and copy over the content. Then delete the original file and give it's name to the new file.

The artifact import now works.