### PR TITLE
Update Windows.EventLogs.Hayabusa

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -9,13 +9,13 @@ description: |
    file for further analysis with excel, timeline explorer, elastic
    stack, jq, etc.
 
-author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity
+author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity, Fukusuke Takahashi - @fukusuket
 
 tools:
- - name: Hayabusa-2.16.0
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.16.0/hayabusa-2.16.0-win-x64.zip
-   expected_hash: 38049502fc482ca83a1a08b050619b55416abc8bb378db10da40b4a47b659389
-   version: 2.16.0
+ - name: Hayabusa-2.16.1
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.16.1/hayabusa-2.16.1-win-x64.zip
+   expected_hash: 1c80c573a9e4f762646910fd5d5c78f7aa1790c1b9ce1510de3bb15893aff52b
+   version: 2.16.1
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -111,7 +111,7 @@ sources:
    query: |
         -- Fetch the binary
         LET Toolzip <= SELECT FullPath
-        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-2.16.0", IsExecutable=FALSE)
+        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-2.16.1", IsExecutable=FALSE)
 
         LET TmpDir <= tempdir()
 
@@ -119,7 +119,7 @@ sources:
         LET _ <= SELECT *
         FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
 
-        LET HayabusaExe <= TmpDir + '\\hayabusa-2.16.0-win-x64.exe'
+        LET HayabusaExe <= TmpDir + '\\hayabusa-2.16.1-win-x64.exe'
 
         -- Optionally update the rules
         LET _ <= if(condition=UpdateRules, then={


### PR DESCRIPTION
Hello :)

Our team released [Hayabusa 2.16.1](https://github.com/Yamato-Security/hayabusa/releases/tag/v2.16.1), so I'll update Hayabusa Artifact.
- ref: https://github.com/Yamato-Security/hayabusa/issues/1389
  - 2.16.0.zip is now detected by WindowsDefender..., so we have excluded the rule from being detected. 

Thank you for your time.