### PR TITLE
Added Windows.Sysinternals.PSShutdown in Artifact Exchange

### DIFF
--- a/content/exchange/artifacts/Windows.Sysinternals.PSShutdown.yaml
+++ b/content/exchange/artifacts/Windows.Sysinternals.PSShutdown.yaml
@@ -54,7 +54,7 @@ sources:
         LET ActionArg <= if(condition=Action="Logoff console user", then="-o", else=ActionArg)
         LET ActionArg <= if(condition=Action="Reboot", then="-r", else=ActionArg)
         LET ActionArg <= if(condition=Action="Shutdown without poweroff", then="-s", else=ActionArg)
-        LET ActionArg <= if(condition=Action="Turn off monitor", then="-x", else=ActionArg)
+        
         
         LET args <= (
             PSShutdown64bin[0].OSPath,
@@ -74,7 +74,10 @@ sources:
         LET args <= if(condition=Action="Abort", then=(PSShutdown64bin[0].OSPath, "-a"), else=args)
         -- so does lock -l
         LET args <= if(condition=Action="Lock", then=(PSShutdown64bin[0].OSPath, "-l"), else=args)
+        -- monitor shutdown too 
+        LET args <= if(condition=Action="Turn off monitor", then=(PSShutdown64bin[0].OSPath, "-x"), else=args)
         
         LET args <= filter(list=args, regex=".+")
         
         SELECT *, args as command FROM execve(argv=args)
+        

--- a/content/exchange/artifacts/Windows.Sysinternals.PSShutdown.yaml
+++ b/content/exchange/artifacts/Windows.Sysinternals.PSShutdown.yaml
@@ -1,0 +1,80 @@
+name: Windows.Sysinternals.PSShutdown
+description: |
+   PsShutdown is a command-line utility similar to the shutdown utility from the Windows 2000 Resource Kit, but with the ability to do much more. In addition to supporting the same options for shutting down or rebooting the local or a remote computer, PsShutdown can logoff the console user or lock the console (locking requires Windows 2000 or higher). PsShutdown requires no manual installation of client software.
+author: Ian Boje
+
+# Can be CLIENT, CLIENT_EVENT, SERVER, SERVER_EVENT or NOTEBOOK
+type: CLIENT
+
+parameters:
+   - name: Action
+     default: Reboot
+     type: choices
+     choices:
+        - Abort
+        - Suspend
+        - Hybernate
+        - Poweroff
+        - Lock
+        - Logoff console user
+        - Reboot
+        - Shutdown without poweroff
+        - Turn off monitor
+   - name: time
+     default: 30
+     description: -t Can be either seconds, or 24 hour clock
+   - name: abortable
+     type: bool
+     description: -c Allows user to cancel shutdown 
+     default: Y
+   - name: force
+     type: bool
+     description: -f Forces all running applications to exit during the shutdown instead of giving them a chance to gracefully save their data.
+   - name: message
+     description: -m This option lets you specify a message to display to logged-on users when a shutdown countdown commences.
+   - name: msgtime
+     description: -v Display message for the specified number of seconds before the shutdown.  If set to 0, no dialog will be displayed.
+
+tools:
+    - name: PSShutdown64
+      url: https://live.sysinternals.com/tools/psshutdown64.exe
+      serve_locally: true
+     
+sources:
+  - precondition:
+      SELECT OS From info() where OS = 'windows'
+
+    query: |
+        LET PSShutdown64bin <= select * from Artifact.Generic.Utils.FetchBinary(ToolName="PSShutdown64")
+        
+        LET ActionArg <= "-r" -- Default if nothing matches
+        LET ActionArg <= if(condition=Action="Suspend", then="-d", else=ActionArg)
+        LET ActionArg <= if(condition=Action="Hybernate", then="-h", else=ActionArg)
+        LET ActionArg <= if(condition=Action="Poweroff", then="-k", else=ActionArg)
+        LET ActionArg <= if(condition=Action="Logoff console user", then="-o", else=ActionArg)
+        LET ActionArg <= if(condition=Action="Reboot", then="-r", else=ActionArg)
+        LET ActionArg <= if(condition=Action="Shutdown without poweroff", then="-s", else=ActionArg)
+        LET ActionArg <= if(condition=Action="Turn off monitor", then="-x", else=ActionArg)
+        
+        LET args <= (
+            PSShutdown64bin[0].OSPath,
+            "-accepteula",
+            ActionArg,
+            "-t",
+            time,
+            if(condition=message, then="-m", else=""),
+            if(condition=message, then=message, else=""),
+            if(condition=abortable, then="-c", else=""),
+            if(condition=force, then="-f", else=""),
+            if(condition=msgtime, then="-v", else=""),
+            if(condition=msgtime, then=msgtime, else="")
+        )
+        
+        -- abort -a deletes all other switches
+        LET args <= if(condition=Action="Abort", then=(PSShutdown64bin[0].OSPath, "-a"), else=args)
+        -- so does lock -l
+        LET args <= if(condition=Action="Lock", then=(PSShutdown64bin[0].OSPath, "-l"), else=args)
+        
+        LET args <= filter(list=args, regex=".+")
+        
+        SELECT *, args as command FROM execve(argv=args)


### PR DESCRIPTION
Added Windows.Sysinternals.PSSShutdown to automate the usage of PSShutdown from Sysinternals.  In addition to all the features of shutdown.exe, this will let you do more advanced features like lock.