### PR TITLE
ESET Endpoint Security Log Parsing Artifact

### DIFF
--- a/content/exchange/artifacts/ESETLogs.yaml
+++ b/content/exchange/artifacts/ESETLogs.yaml
@@ -1,0 +1,69 @@
+name: Windows.ESET.Logs
+description: |
+   Parse logs from ESET antivirus products. This log contains information about detections made by the ESET modules such as Real-time filesystem proteciton, Firewall, HIPS, Device Control, HTTP filter, AMSI Scanner etc.
+ 
+type: CLIENT
+ 
+tools:
+  - name: ESETLogCollector
+    url: https://download.eset.com/com/eset/tools/diagnosis/log_collector/latest/esetlogcollector.exe
+    serve_locally: true
+ 
+precondition: SELECT OS From info() where OS = 'windows'
+ 
+parameters:
+   - name: LogTargets
+     default: "Threat,Hips,Fw,Web,Dev,BlkF"
+     description: Selection of log targets to collect
+ 
+required_permissions:
+- EXECVE
+ 
+sources:
+  - name: Antivirus
+    query: |
+        LET tool <= SELECT * FROM Artifact.Generic.Utils.FetchBinary(ToolName="ESETLogCollector")
+        LET tempfolder <= tempdir(remove_last=true)
+        LET exe <= SELECT * FROM execve(argv= [ tool[0].OSPath,
+           "/accepteula", "/OType:xml", "/Targets:"+LogTargets, tempfolder+'\\logstmp.zip' ], length=10000000)
+        LET zip <= SELECT * FROM unzip(filename=tempfolder+'\\logstmp.zip',output_directory=tempfolder+'\\logs')
+         
+        LET xml <= SELECT get(item=parse_xml(file=OSPath), member='Events.Event') AS entries FROM glob(globs=tempfolder+'\\logs\\ESET\\Logs\\Common\\virlog.dat.xml')
+        SELECT * FROM foreach(
+            row=xml.entries,
+            query={SELECT _value.AttrIdx AS ID, _value.AttrTime AS Timestamp, 'virlog.dat' AS Log, _value.Threat AS Threat, _value.AttrLevel AS Level, _value.Action AS Action, _value.Name AS Object, _value.Col7 AS SHA1, _value.Info AS Information, _value.Col8 AS Firstseen, _value.Scanner AS Scanner, _value.Object AS ObjectType, _value.User AS User, _value.AttrDeleted AS DeletedInLog FROM foreach(row=_value)})
+            
+  - name: HIPS
+    query: |
+        LET xml <= SELECT get(item=parse_xml(file=OSPath), member='Events.Event') AS entries FROM glob(globs=tempfolder+'\\logs\\ESET\\Logs\\Common\\hipslog.dat.xml')
+        SELECT _value.AttrIdx AS ID, _value.AttrTime AS Timestamp, 'hipslog.dat' AS Log, _value.Rule AS RuleName, _value.AttrLevel AS Level, _value.Action AS Action, _value.Application AS Application, _value.Application_Hash AS ApplicationSHA1, _value.Target AS Target, _value.Target_Hash AS TargetSHA1, _value.AttrDeleted AS DeletedInLog FROM foreach(
+            row=xml.entries,
+            query={SELECT * FROM foreach(row=_value)})  
+             
+  - name: Firewall
+    query: |
+        LET xml <= SELECT get(item=parse_xml(file=OSPath), member='Events.Event') AS entries FROM glob(globs=tempfolder+'\\logs\\ESET\\Logs\\Net\\epfwlog.dat.xml')
+        SELECT _value.AttrIdx AS ID, _value.AttrTime AS Timestamp, 'epfwlog.dat' AS Log, _value.Event AS Event, _value.Rule_worm_name AS RuleName, _value.AttrLevel AS Level, _value.Action AS Action, _value.Source AS Source, _value.Target AS Target, _value.Protocol AS Protocol, _value.Application AS Application, _value.Hash AS SHA1, _value.User AS User, _value.AttrDeleted AS DeletedInLog FROM foreach(
+            row=xml.entries,
+            query={SELECT * FROM foreach(row=_value)})
+             
+  - name: FilteredWebsites
+    query: |
+        LET xml <= SELECT get(item=parse_xml(file=OSPath), member='Events.Event') AS entries FROM glob(globs=tempfolder+'\\logs\\ESET\\Logs\\Net\\urllog.dat.xml')
+        SELECT _value.AttrIdx AS ID, _value.AttrTime AS Timestamp, 'urllog.dat' AS Log, _value.URL AS URL, _value.Status AS Action, _value.Detection AS Threat, _value.AttrLevel AS Level, _value.Application AS Application, _value.Hash AS SHA1, _value.User AS User, _value.IP_address AS IPAddress, _value.AttrDeleted AS DeletedInLog FROM foreach(
+            row=xml.entries,
+            query={SELECT * FROM foreach(row=_value)})
+             
+  - name: BlockedFiles
+    query: |
+        LET xml <= SELECT get(item=parse_xml(file=OSPath), member='Events.Event') AS entries FROM glob(globs=tempfolder+'\\logs\\ESET\\Logs\\Common\\blocked.dat.xml')
+        SELECT _value.AttrIdx AS ID, _value.AttrTime AS Timestamp, 'blocked.dat' AS Log, _value.File AS File, _value.Source AS Blocker, _value.Reason AS Reason, _value.AttrLevel AS Level, _value.Application AS Application, _value.Hash AS SHA1, _value.User AS User, _value.First_seen_here AS FirstSeen, _value.AttrDeleted AS DeletedInLog FROM foreach(
+            row=xml.entries,
+            query={SELECT * FROM foreach(row=_value)})
+             
+  - name: DeviceControl
+    query: |
+        LET xml <= SELECT get(item=parse_xml(file=OSPath), member='Events.Event') AS entries FROM glob(globs=tempfolder+'\\logs\\ESET\\Logs\\Common\\devctrllog.dat.xml')
+        SELECT _value.AttrIdx AS ID, _value.AttrTime AS Timestamp, 'devctrllog.dat' AS Log, _value.Device AS Device, _value.Status AS Action, _value.AttrLevel AS Level, _value.User AS User, _value.User_SID AS SID, _value.Group AS Group, _value.Group_SID AS GroupSID, _value.Device_details AS DeviceDetails, _value.Event_details AS EventDetails, _value.AttrDeleted AS DeletedInLog FROM foreach(
+            row=xml.entries,
+            query={SELECT * FROM foreach(row=_value)})

--- a/content/exchange/artifacts/ESETLogs.yaml
+++ b/content/exchange/artifacts/ESETLogs.yaml
@@ -1,4 +1,5 @@
 name: Windows.ESET.Logs
+author: Ján Trenčanský - j91321@infosec.exchange
 description: |
    Parse logs from ESET antivirus products. This log contains information about detections made by the ESET modules such as Real-time filesystem proteciton, Firewall, HIPS, Device Control, HTTP filter, AMSI Scanner etc.
  

--- a/content/exchange/artifacts/ESETLogs.yaml
+++ b/content/exchange/artifacts/ESETLogs.yaml
@@ -8,6 +8,7 @@ type: CLIENT
 tools:
   - name: ESETLogCollector
     url: https://download.eset.com/com/eset/tools/diagnosis/log_collector/latest/esetlogcollector.exe
+    expected_hash: c5c9b4ec7feca3f3ac43c71454e7e51f13f19ce52a0583d34b32f7df4bbea5db
     serve_locally: true
  
 precondition: SELECT OS From info() where OS = 'windows'


### PR DESCRIPTION
Artifact that uses ESET Log Collector tool to convert threat logs into XMLs and parse them through Velociraptor. Covers all important log sources that are commonly encountered in enterprise setting. Tested on ESET Endpoint Security. 

Examples:
![image](https://github.com/user-attachments/assets/e4d0ec41-a512-4301-a1a5-6250aedd353b)

![image](https://github.com/user-attachments/assets/9326ae3a-0ca6-493e-9934-7c631fdaadfe)

![image](https://github.com/user-attachments/assets/aae0ded3-242c-488e-a353-7d013fb1ee49)
