### PR TITLE
Update Windows.EventLogs.Hayabusa

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -12,10 +12,10 @@ description: |
 author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity, Fukusuke Takahashi - @fukusuket
 
 tools:
- - name: Hayabusa-2.17.0
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.17.0/hayabusa-2.17.0-win-x64.zip
-   expected_hash: 7ad371b4f567af590edcd3740a939f738aebb56ac1481c1036a031aa46aace28
-   version: 2.17.0
+ - name: Hayabusa-2.18.0
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.18.0/hayabusa-2.18.0-win-x64-live-response.zip
+   expected_hash: 9c0d0839297449506c63533c75bf4f319e029a626faace64a22d562ecff37b7b
+   version: 2.18.0
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -111,7 +111,7 @@ sources:
    query: |
         -- Fetch the binary
         LET Toolzip <= SELECT FullPath
-        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-2.17.0", IsExecutable=FALSE)
+        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-2.18.0", IsExecutable=FALSE)
 
         LET TmpDir <= tempdir()
 
@@ -119,7 +119,7 @@ sources:
         LET _ <= SELECT *
         FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
 
-        LET HayabusaExe <= TmpDir + '\\hayabusa-2.17.0-win-x64.exe'
+        LET HayabusaExe <= TmpDir + '\\hayabusa-2.18.0-win-x64.exe'
 
         -- Optionally update the rules
         LET _ <= if(condition=UpdateRules, then={

--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -14,7 +14,7 @@ author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Math
 tools:
  - name: Hayabusa-2.18.0
    url: https://github.com/Yamato-Security/hayabusa/releases/download/v2.18.0/hayabusa-2.18.0-win-x64-live-response.zip
-   expected_hash: 9c0d0839297449506c63533c75bf4f319e029a626faace64a22d562ecff37b7b
+   expected_hash: f52d51f62bb3b4cb4a6e9f66716d024e022f22a3c9b0c44386ee25d67853668a
    version: 2.18.0
 
 precondition: SELECT OS From info() where OS = 'windows'
@@ -123,7 +123,7 @@ sources:
 
         -- Optionally update the rules
         LET _ <= if(condition=UpdateRules, then={
-        SELECT * FROM execve(argv=['cmd.exe', '/c', 'cd', TmpDir, '&', HayabusaExe, 'update-rules']) })
+        SELECT * FROM execve(argv=[HayabusaExe, 'update-rules'], cwd=TmpDir) })
 
         LET HayabusaCmd <= if(condition=OutputFormat = "csv", then="csv-timeline", else="json-timeline")
         LET ResultFile <= TmpDir + '\\hayabusa_results.' + OutputFormat
@@ -158,7 +158,7 @@ sources:
 
         -- Run the tool and divert messages to logs.
         LET ExecHB <= SELECT *
-        FROM execve(argv=cmdline, sep="\n", length=9999999)
+        FROM execve(argv=cmdline, cwd=TmpDir, sep="\n", length=9999999)
         WHERE log(message=Stdout)
 
         -- Upload the raw file.


### PR DESCRIPTION
Hello :)
Our team released [Hayabusa 2.18.0](https://github.com/Yamato-Security/hayabusa/releases/tag/v2.18.0), so I'll update Hayabusa Artifact.

@scudette 
Thanks to your advice https://github.com/Yamato-Security/hayabusa/issues/1356 , we implemented the following features in this version.
- https://github.com/Yamato-Security/hayabusa/pull/1419
- https://github.com/Yamato-Security/hayabusa/pull/1423

Using **hayabusa-2.18.0-win-x64-live-response.zip** with Artifact will automatically enable the above features.
Thank you so much!