### PR TITLE
Update Windows.Sys.BitLocker.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Sys.BitLocker.yaml
+++ b/content/exchange/artifacts/Windows.Sys.BitLocker.yaml
@@ -22,7 +22,9 @@ sources:
                 $Results += $_
             }
         }
-        return ($Results | ConvertTo-Json)'''
+        
+        return ConvertTo-Json -InputObject @($Results)
+        '''
         SELECT * FROM foreach(
           row={
             SELECT Stdout FROM execve(argv=["Powershell", "-ExecutionPolicy",


### PR DESCRIPTION
Fix bug where it wasn't always working due to ConvertTo-Json sometimes returning a single object instead of an array.