### PR TITLE
Fix and improve nethogs artifacts

### DIFF
--- a/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
@@ -2,18 +2,18 @@ name: Linux.Event.Network.Nethogs
 author: 'Andreas Misje - @misje'
 type: CLIENT_EVENT
 description: |
-  Monitor network bandwidth per process, using "nethogs". This artifact will
+  Monitor network use per process using the tool "nethogs". This artifact will
   list all processes that produces (non-local) network traffic on the client,
   leveraging the process tracker, and displays the bytes received and sent in
-  the given time frame. A notebook suggestion gives you the total byte count as
-  well.
+  bytes per second.
 
   Note that the tool/package "nethogs" needs to be installed before calling this
   artifact. Set the paramater InstallNethogs to true in order to automatically
   install the package and its dependencies (Debian-based systems only).
 
-  Short-lived processes that only run for less than one second will not be shown
-  unless a process tracker is installed on the system (*.Events.TrackProcesses).
+  Using techniques like stacking, rare occurances of processes contacting the
+  Internet can be spotted. Notebook suggestions give you total traffic overview,
+  as well as boilerplate code to plot the traffic for a selected process.
 
 parameters:
   - name: InstallNethogs
@@ -21,88 +21,231 @@ parameters:
     type: bool
     default: false
 
+  - name: ProcessCachePeriod
+    description: Number of seconds to cache the process tracker data
+    type: int
+    default: 10
+
+  - name: ProcessRegex
+    description: |
+      Only look for processes whose name / command line matches this regex
+    type: regex
+    default: .+
+
+  - name: PIDRegex
+    description: |
+      Only look for processes whose PID matches this regex
+    type: regex
+    default: .+
+
+  - name: UIDRegex
+    description: |
+      Only look for processes whose owner ID (UID) matches this regex
+    type: regex
+    default: .+
+
 precondition:
   SELECT * FROM info() where OS = 'linux'
 
 sources:
     - query: |
-       LET Hoggers = SELECT Process,
-                            PID,
-                            UID,
-                            Sent,
-                            Recv
-         FROM foreach(
-           row={
-             SELECT *
-             FROM execve(argv=['/usr/sbin/nethogs', '-t', '-v', '2'],
-                         length=10000,
-                         sep='\n\nRefreshing:\n')
-           },
-           query={
-             SELECT timestamp(epoch=now()) AS Timestamp,
-                    *
-             FROM parse_records_with_regex(
-               accessor='data',
-               file=Stdout,
-               regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>\d+)\t(?P<Recv>\d+)''')
-           })
+         LET Hoggers = SELECT Timestamp,
+                              Process,
+                              PID,
+                              UID,
+                              parse_float(string=Sent) AS Sent,
+                              parse_float(string=Recv) AS Recv
+           FROM foreach(
+             row={
+               SELECT *
+               FROM execve(argv=['/usr/sbin/nethogs', '-t'],
+                           length=10000,
+                           sep='\n\nRefreshing:\n')
+             },
+             query={
+               SELECT timestamp(epoch=now()) AS Timestamp,
+                      *
+               FROM parse_records_with_regex(
+                 accessor='data',
+                 file=Stdout,
+                 regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>[^\t]+)\t(?P<Recv>\S+)''')
+               WHERE Process =~ ProcessRegex
+                AND PID =~ PIDRegex
+                     AND UID =~ UIDRegex
+             })
 
-       LET Result = SELECT
-                           int(
-                             int=PID) AS PID,
-                           *
-         FROM foreach(
-           row={
-             SELECT *
-             FROM Hoggers
-           },
-           query={
-             SELECT
-                    PID,
-                    Name,
-                    CommandLine,
-                    Cwd,
-                    UID AS _UID,
-                    Username,
-                    StartTime,
-                    if(
-                      condition=EndTime.Unix < 0,
-                      then=NULL,
-                      else=EndTime) AS Endtime,
-                    int(
-                      int=Sent) AS Sent,
-                    int(
-                      int=Recv) AS Recv
-             FROM process_tracker_pslist()
-             WHERE Pid = PID
-           })
+         // Trick for avoiding errors when referencing non-existent variables:
+         LET S = scope()
 
-       LET InstallDeps = SELECT *
-         FROM if(
-           condition=InstallNethogs,
-           then={
-             SELECT *
-             FROM Artifact.Linux.Utils.InstallDeb(DebName='nethogs')
-           })
+         // Memoize the process list since we will be referencing a lot:
+         LET Processes <= memoize(
+             name='ps',
+             key='PID',
+             period=ProcessCachePeriod,
+             query={
+               SELECT 
+                      Pid AS PID,
+                      Name,
+                      CommandLine,
+                      // CurrentDirectory is not always available:
+                      S.CurrentDirectory AS CWD,
+                      Username,
+                      StartTime,
+                      // Do not show a silly timestamp parsed from an invalid value:
+                      if(
+                        condition=EndTime.Unix < 0,
+                        then=NULL,
+                        else=EndTime) AS EndTime
+               FROM process_tracker_pslist()
+             })
 
-       SELECT *
-       FROM chain(a_install=InstallDeps,
-                  b_result=Result)
+         LET Result = SELECT *
+           FROM foreach(
+             row={
+               SELECT *
+               FROM Hoggers
+             },
+             query={
+               SELECT *
+               FROM foreach(
+                 row={
+                   SELECT 
+                          dict(
+                            Timestamp=Timestamp,
+                            Process=Process,
+                            PID=PID,
+                            UID=UID,
+                            Sent=Sent,
+                            /* "left--outer-join" the process data so that output
+                               from nethogs without a matching PID still gets logged:
+                            */
+                            Recv=Recv) + (get(
+                              item=Processes,
+                              field=PID) || dict(
+                              Name=Process,
+                              CommandLine=NULL,
+                              CWD=NULL,
+                              Username=NULL,
+                              StartTime=NULL,
+                              EndTime=NULL)) AS Contents
+                   FROM scope()
+                   WHERE Contents
+                 },
+                 column='Contents')
+             })
+
+         // Leverage the InstallDeb utility to do the actual package install:
+         LET InstallDeps = SELECT *
+           FROM if(
+             condition=InstallNethogs,
+             then={
+               SELECT *
+               FROM Artifact.Linux.Utils.InstallDeb(DebName='nethogs')
+             })
+
+         SELECT *
+         FROM chain(a_install=InstallDeps,
+                    b_result=Result)
 
       notebook:
+        - type: vql
+          name: Traffic
+          template: |
+            // Modify these to adjust the time frame:
+            // LET StartTime <= '2024-01-01T00:00:00Z'
+            // LET EndTimeTime <= '2024-01-01T00:00:00Z'
+            /*
+            # Network traffic
+
+            {{ $TimeRange := Query "SELECT StartTime, EndTime FROM scope()" | Expand }}
+            Network traffic (in bytes per second) between {{ Get $TimeRange "0.StartTime" }}
+            and {{ Get $TimeRange "0.EndTime" }}
+            */
+            SELECT Timestamp,
+                   PID,
+                   Name,
+                   CommandLine,
+                   CWD,
+                   Username,
+                   StartTime,
+                   EndTime,
+                   humanize(bytes=Sent*1024) AS Sent,
+                   humanize(bytes=Recv*1024) AS Recv
+            FROM source(start_time=StartTime, end_time=EndTime)
+
         - type: vql_suggestion
           name: Total traffic
           template: |
-               /*
-               # Total traffic
-               */
-               SELECT
-                      Name,
-                      humanize(
-                        bytes=sum(
-                            item=Sent)) AS Sent,
-                      humanize(
-                        bytes=sum(
-                            item=Recv)) AS Recv
-               FROM source()
-               GROUP BY Name
+            // Modify these to adjust the time frame:
+            // LET StartTime <= '2024-01-01T00:00:00Z'
+            // LET EndTimeTime <= '2024-01-01T00:00:00Z'
+            /*
+            # Network traffic summary
+
+            {{ $TimeRange := Query "SELECT StartTime, EndTime FROM scope()" | Expand }}
+            This is a **rough estimate** of the total bytes sent and received between
+            {{ Get $TimeRange "0.StartTime" }} and {{ Get $TimeRange "0.EndTime" }}.
+            Run the non-event artifact Linux.Network.Nethogs in Volume mode for
+            an exact measurement.
+            */
+            LET Summary = SELECT 
+                     PID,
+                     Name,
+                     CommandLine,
+                     CWD,
+                     Username,
+                     StartTime,
+                     EndTime,
+                     // nethogs -t outputs a data rate every second. Adding these
+                     // values give us a rough estimate of the data transferred
+                     sum(
+                       item=Sent * 1024) AS Sent,
+                     sum(
+                       item=Recv * 1024) AS Recv
+              FROM source(start_time=StartTime,
+                          end_time=EndTime)
+              GROUP BY PID
+
+            SELECT *,
+                   humanize(
+                     bytes=Sent) AS Sent,
+                   humanize(
+                     bytes=Recv) AS Recv,
+                   humanize(
+                     bytes=sum(
+                       item=Recv + Sent)) AS Total
+            FROM Summary
+
+        - type: vql_suggestion
+          name: Plot traffic for PID
+          template: |
+            // Modify these to adjust the time frame:
+            // LET StartTime <= '2024-01-01T00:00:00Z'
+            // LET EndTimeTime <= '2024-01-01T00:00:00Z'
+            // The process whose traffic to plot (PID 0 here happens to be "Unknown traffic"
+            // from nethogs):
+            LET PIDTarget = '0'
+
+            /*
+            {{ $Vars := Query "SELECT PIDTarget, StartTime, EndTime FROM scope()" | Expand }}
+            # Network traffic for PID {{ Get $Vars "0.PIDTarget" }}
+
+            Network traffic (in bytes per second) between {{ Get $Vars "0.StartTime" }}
+            and {{ Get $Vars "0.EndTime" }}
+            */
+            LET SinglePSStats = SELECT 
+                                       Timestamp.Unix AS Timestamp,
+                                       Sent * 1024 AS Sent,
+                                       Recv * 1024 AS Recv
+              FROM source(start_time=StartTime,
+                          end_time=EndTime)
+              WHERE PID = PIDTarget
+
+            /*
+            {{ Query "SELECT * FROM SinglePSStats" | TimeChart }}
+            */
+
+            // We do not really need this, but we need to execute some VQL
+            // in order for the plot to appear:
+            SELECT *
+            FROM SinglePSStats

--- a/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
@@ -3,9 +3,10 @@ author: 'Andreas Misje - @misje'
 type: CLIENT_EVENT
 description: |
   Monitor network use per process using the tool "nethogs". This artifact will
-  list all processes that produces (non-local) network traffic on the client,
-  leveraging the process tracker, and displays the bytes received and sent in
-  bytes per second.
+  list all processes that produces (non-local) network traffic on the client.
+  The NetstatEnriched artifact is used to provide detailed information about the
+  process using netstat and the process tracker, along with the bytes received
+  and sent in bytes per second.
 
   Note that the tool/package "nethogs" needs to be installed before calling this
   artifact. Set the paramater InstallNethogs to true in order to automatically
@@ -21,8 +22,8 @@ parameters:
     type: bool
     default: false
 
-  - name: ProcessCachePeriod
-    description: Number of seconds to cache the process tracker data
+  - name: NetstatCachePeriod
+    description: Number of seconds to cache netstat data
     type: int
     default: 10
 
@@ -51,7 +52,7 @@ sources:
     - query: |
          LET Hoggers = SELECT Timestamp,
                               Process,
-                              PID,
+                              int(int=PID) AS PID,
                               UID,
                               parse_float(string=Sent) AS Sent,
                               parse_float(string=Recv) AS Recv
@@ -74,29 +75,13 @@ sources:
                      AND UID =~ UIDRegex
              })
 
-         // Trick for avoiding errors when referencing non-existent variables:
-         LET S = scope()
-
-         // Memoize the process list since we will be referencing a lot:
-         LET Processes <= memoize(
-             name='ps',
-             key='PID',
-             period=ProcessCachePeriod,
+         LET Netstat <= memoize(
+             name='netstat',
+             key='Pid',
+             period=NetstatCachePeriod,
              query={
-               SELECT 
-                      Pid AS PID,
-                      Name,
-                      CommandLine,
-                      // CurrentDirectory is not always available:
-                      S.CurrentDirectory AS CWD,
-                      Username,
-                      StartTime,
-                      // Do not show a silly timestamp parsed from an invalid value:
-                      if(
-                        condition=EndTime.Unix < 0,
-                        then=NULL,
-                        else=EndTime) AS EndTime
-               FROM process_tracker_pslist()
+               SELECT *
+               FROM Artifact.Linux.Network.NetstatEnriched()
              })
 
          LET Result = SELECT *
@@ -116,18 +101,22 @@ sources:
                             PID=PID,
                             UID=UID,
                             Sent=Sent,
-                            /* "left--outer-join" the process data so that output
-                               from nethogs without a matching PID still gets logged:
-                            */
-                            Recv=Recv) + (get(
-                              item=Processes,
-                              field=PID) || dict(
-                              Name=Process,
+                            Recv=Recv,
+                            ProcInfo=dict(
                               CommandLine=NULL,
-                              CWD=NULL,
                               Username=NULL,
-                              StartTime=NULL,
-                              EndTime=NULL)) AS Contents
+                              StartTime=NULL)) + (get(
+                              item=Netstat,
+                              field=PID) || dict(
+                              Name=NULL,
+                              Laddr=NULL,
+                              Lport=NULL,
+                              Raddr=NULL,
+                              Rport=NULL,
+                              Status=NULL,
+                              ProcInfo=dict(),
+                              CallChain=NULL,
+                              ChildrenTree=NULL)) AS Contents
                    FROM scope()
                    WHERE Contents
                  },
@@ -161,17 +150,31 @@ sources:
             Network traffic (in bytes per second) between {{ Get $TimeRange "0.StartTime" }}
             and {{ Get $TimeRange "0.EndTime" }}
             */
-            SELECT Timestamp,
+            LET ColumnTypes = dict(
+                _ChildrenTree='tree')
+            
+            SELECT 
+                   Timestamp,
                    PID,
-                   Name,
-                   CommandLine,
-                   CWD,
-                   Username,
-                   StartTime,
-                   EndTime,
-                   humanize(bytes=Sent*1024) AS Sent,
-                   humanize(bytes=Recv*1024) AS Recv
-            FROM source(start_time=StartTime, end_time=EndTime)
+                   ProcInfo.Name || Process AS Name,
+                   ProcInfo.CommandLine AS CmdLine,
+                   ProcInfo.Username AS Username,
+                   ProcInfo.StartTime AS StartTime,
+                   Laddr,
+                   Lport,
+                   Raddr,
+                   Rport,
+                   Status,
+                   humanize(
+                     bytes=Sent * 1024) AS Sent,
+                   humanize(
+                     bytes=Recv * 1024) AS Recv,
+                   ProcInfo AS _ProcInfo,
+                   CallChain AS _CalLChain,
+                   ChildrenTree AS _ChildrenTree
+            FROM source(start_time=StartTime,
+                        end_time=EndTime)
+            LIMIT 50
 
         - type: vql_suggestion
           name: Total traffic
@@ -185,17 +188,13 @@ sources:
             {{ $TimeRange := Query "SELECT StartTime, EndTime FROM scope()" | Expand }}
             This is a **rough estimate** of the total bytes sent and received between
             {{ Get $TimeRange "0.StartTime" }} and {{ Get $TimeRange "0.EndTime" }}.
-            Run the non-event artifact Linux.Network.Nethogs in Volume mode for
-            an exact measurement.
             */
             LET Summary = SELECT 
                      PID,
-                     Name,
-                     CommandLine,
-                     CWD,
-                     Username,
-                     StartTime,
-                     EndTime,
+                     ProcInfo.Name || Process AS Name,
+                     ProcInfo.CommandLine AS CommandLine,
+                     ProcInfo.Username AS Username,
+                     ProcInfo.StartTime AS StartTime,
                      // nethogs -t outputs a data rate every second. Adding these
                      // values give us a rough estimate of the data transferred
                      sum(
@@ -205,16 +204,16 @@ sources:
               FROM source(start_time=StartTime,
                           end_time=EndTime)
               GROUP BY PID
-
+            
             SELECT *,
                    humanize(
                      bytes=Sent) AS Sent,
                    humanize(
                      bytes=Recv) AS Recv,
                    humanize(
-                     bytes=sum(
-                       item=Recv + Sent)) AS Total
+                     bytes=Recv + Sent) AS Total
             FROM Summary
+            LIMIT 50
 
         - type: vql_suggestion
           name: Plot traffic for PID
@@ -224,7 +223,7 @@ sources:
             // LET EndTimeTime <= '2024-01-01T00:00:00Z'
             // The process whose traffic to plot (PID 0 here happens to be "Unknown traffic"
             // from nethogs):
-            LET PIDTarget = '0'
+            LET PIDTarget = 0
 
             /*
             {{ $Vars := Query "SELECT PIDTarget, StartTime, EndTime FROM scope()" | Expand }}
@@ -240,6 +239,7 @@ sources:
               FROM source(start_time=StartTime,
                           end_time=EndTime)
               WHERE PID = PIDTarget
+              LIMIT 50
 
             /*
             {{ Query "SELECT * FROM SinglePSStats" | TimeChart }}

--- a/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
@@ -4,12 +4,23 @@ type: CLIENT_EVENT
 description: |
   Monitor network bandwidth per process, using "nethogs". This artifact will
   list all processes that produces (non-local) network traffic on the client,
-  leveraging the process tracker, and displays the total bytes received and sent
-  in the given time frame.
-  
+  leveraging the process tracker, and displays the bytes received and sent in
+  the given time frame. A notebook suggestion gives you the total byte count as
+  well.
+
   Note that the tool/package "nethogs" needs to be installed before calling this
-  artifact.
-    
+  artifact. Set the paramater InstallNethogs to true in order to automatically
+  install the package and its dependencies (Debian-based systems only).
+
+  Short-lived processes that only run for less than one second will not be shown
+  unless a process tracker is installed on the system (*.Events.TrackProcesses).
+
+parameters:
+  - name: InstallNethogs
+    description: Install nethogs using apt-get
+    type: bool
+    default: false
+
 precondition:
   SELECT * FROM info() where OS = 'linux'
 
@@ -23,7 +34,7 @@ sources:
          FROM foreach(
            row={
              SELECT *
-             FROM execve(argv=['/usr/sbin/nethogs', '-t'],
+             FROM execve(argv=['/usr/sbin/nethogs', '-t', '-v', '2'],
                          length=10000,
                          sep='\n\nRefreshing:\n')
            },
@@ -33,25 +44,65 @@ sources:
              FROM parse_records_with_regex(
                accessor='data',
                file=Stdout,
-               regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>\d+\.\d+|0)\t(?P<Recv>\d+\.\d+|0)''')
+               regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>\d+)\t(?P<Recv>\d+)''')
            })
+
+       LET Result = SELECT
+                           int(
+                             int=PID) AS PID,
+                           *
+         FROM foreach(
+           row={
+             SELECT *
+             FROM Hoggers
+           },
+           query={
+             SELECT
+                    PID,
+                    Name,
+                    CommandLine,
+                    Cwd,
+                    UID AS _UID,
+                    Username,
+                    StartTime,
+                    if(
+                      condition=EndTime.Unix < 0,
+                      then=NULL,
+                      else=EndTime) AS Endtime,
+                    int(
+                      int=Sent) AS Sent,
+                    int(
+                      int=Recv) AS Recv
+             FROM process_tracker_pslist()
+             WHERE Pid = PID
+           })
+
+       LET InstallDeps = SELECT *
+         FROM if(
+           condition=InstallNethogs,
+           then={
+             SELECT *
+             FROM Artifact.Linux.Utils.InstallDeb(DebName='nethogs')
+           })
+
        SELECT *
-       FROM foreach(
-         row={
-           SELECT *
-           FROM Hoggers
-         },
-         query={
-           SELECT 
-                  Pid,
-                  Name,
-                  CommandLine,
-                  Cwd,
-                  Username,
-                  StartTime,
-                  EndTime,
-                  Sent,
-                  Recv
-           FROM process_tracker_pslist()
-           WHERE Pid = PID
-         })
+       FROM chain(a_install=InstallDeps,
+                  b_result=Result)
+
+      notebook:
+        - type: vql_suggestion
+          name: Total traffic
+          template: |
+               /*
+               # Total traffic
+               */
+               SELECT
+                      Name,
+                      humanize(
+                        bytes=sum(
+                            item=Sent)) AS Sent,
+                      humanize(
+                        bytes=sum(
+                            item=Recv)) AS Recv
+               FROM source()
+               GROUP BY Name

--- a/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Event.Network.Nethogs.yaml
@@ -59,7 +59,7 @@ sources:
            FROM foreach(
              row={
                SELECT *
-               FROM execve(argv=['/usr/sbin/nethogs', '-t'],
+               FROM execve(argv=['/usr/sbin/nethogs', '-t', '-C'],
                            length=10000,
                            sep='\n\nRefreshing:\n')
              },
@@ -203,7 +203,7 @@ sources:
                        item=Recv * 1024) AS Recv
               FROM source(start_time=StartTime,
                           end_time=EndTime)
-              GROUP BY PID
+              GROUP BY PID, Name
             
             SELECT *,
                    humanize(
@@ -221,9 +221,8 @@ sources:
             // Modify these to adjust the time frame:
             // LET StartTime <= '2024-01-01T00:00:00Z'
             // LET EndTimeTime <= '2024-01-01T00:00:00Z'
-            // The process whose traffic to plot (PID 0 here happens to be "Unknown traffic"
-            // from nethogs):
-            LET PIDTarget = 0
+            // The process whose traffic to plot:
+            LET PIDTarget = 1234
 
             /*
             {{ $Vars := Query "SELECT PIDTarget, StartTime, EndTime FROM scope()" | Expand }}

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -1,7 +1,7 @@
 name: Linux.Network.Nethogs
 author: 'Andreas Misje - @misje'
 description: |
-  Monitor network bandwidth per process, using "nethogs". This artifact will
+  Monitor network use per process using the tool "nethogs". This artifact will
   list all processes that produces (non-local) network traffic on the client.
   The NetstatEnriched artifact is used to provide detailed information about the
   process using netstat and the process tracker, along with the bytes received

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -2,16 +2,20 @@ name: Linux.Network.Nethogs
 author: 'Andreas Misje - @misje'
 description: |
   Monitor network bandwidth per process, using "nethogs". This artifact will
-  list all processes that produces (non-local) network traffic on the client,
-  leveraging the process tracker, and displays the total bytes received and sent
-  in the given time frame.
+  list all processes that produces (non-local) network traffic on the client.
+  The NetstatEnriched artifact is used to provide detailed information about the
+  process using netstat and the process tracker, along with the bytes received
+  and sent in bytes per second.
 
   Note that the tool/package "nethogs" needs to be installed before calling this
   artifact. Set the parameter InstallNethogs to true in order to automatically
   install the package and its dependencies (Debian-based systems only).
 
-  Short-lived processes that only run for less than one second will not be shown
-  unless a process tracker is installed on the system (*.Events.TrackProcesses).
+  Using techniques like stacking, rare occurances of processes contacting the
+  Internet can be spotted. Notebook suggestions give you total traffic overview,
+  as well as boilerplate code to plot the traffic for a selected process.
+
+  Also see Linux.Event.Network.Nethogs for a nethogs event artifact.
 
 parameters:
   - name: InstallNethogs
@@ -20,80 +24,228 @@ parameters:
     default: false
 
   - name: Duration
-    type: integer
+    type: int
     description: Number of seconds to monitor processes
     default: 300
+
+  - name: NetstatCachePeriod
+    description: Number of seconds to cache netstat data
+    type: int
+    default: 10
+
+  - name: ProcessRegex
+    description: |
+      Only look for processes whose name / command line matches this regex
+    type: regex
+    default: .+
+
+  - name: PIDRegex
+    description: |
+      Only look for processes whose PID matches this regex
+    type: regex
+    default: .+
+
+  - name: UIDRegex
+    description: |
+      Only look for processes whose owner ID (UID) matches this regex
+    type: regex
+    default: .+
 
 precondition:
   SELECT * FROM info() where OS = 'linux'
 
 sources:
     - query: |
-       LET Hoggers <= SELECT Process,
-                             PID,
-                             int(int=UID) AS UID,
-                             humanize(bytes=parse_float(string=Sent) * 1024) AS Sent,
-                             humanize(
-                               bytes=parse_float(
-                                 string=Recv) * 1024) AS Recv
-         FROM query(
-           timeout=Duration,
-           query={
-             SELECT
-                    Process,
-                    PID,
-                    UID,
-                    Sent,
-                    Recv
-             FROM foreach(
-               row={
-                 SELECT *
-                 FROM execve(argv=['/usr/sbin/nethogs', '-v', '1', '-t'],
-                             length=10000,
-                             sep='\n\nRefreshing:\n')
-               },
-               query={
-                 SELECT *
-                 FROM parse_records_with_regex(
-                   accessor='data',
-                   file=Stdout,
-                   regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>\d+\.\d+|0)\t(?P<Recv>\d+\.\d+|0)''')
-               })
-           })
-         GROUP BY Process
+         LET Hoggers = SELECT Timestamp,
+                              Process,
+                              int(int=PID) AS PID,
+                              UID,
+                              parse_float(string=Sent) AS Sent,
+                              parse_float(string=Recv) AS Recv
+           FROM query(
+             timeout=Duration,
+             inherit=true,
+             query={
+               SELECT *
+               FROM foreach(
+                 row={
+                   SELECT *
+                   FROM execve(argv=['/usr/sbin/nethogs', '-t'],
+                               length=10000,
+                               sep='\n\nRefreshing:\n')
+                 },
+                 query={
+                   SELECT timestamp(epoch=now()) AS Timestamp,
+                          *
+                   FROM parse_records_with_regex(
+                     accessor='data',
+                     file=Stdout,
+                     regex='''^\s*(?P<Process>[^\t]+)/(?P<PID>\d+)/(?P<UID>\d+)\t(?P<Sent>[^\t]+)\t(?P<Recv>\S+)''')
+                   WHERE Process =~ ProcessRegex
+                    AND PID =~ PIDRegex
+                         AND UID =~ UIDRegex
+                 })
+             })
 
-       LET Result = SELECT *
-         FROM foreach(
-           row={
-             SELECT *
-             FROM Hoggers
-           },
-           query={
-             SELECT
-                    int(int=PID) AS PID,
-                    Name,
-                    CommandLine,
-                    Cwd,
-                    Username,
-                    StartTime,
-                    if(
-                      condition=EndTime.Unix < 0,
-                      then=NULL,
-                      else=EndTime) AS EndTime,
-                    Sent,
-                    Recv
-             FROM process_tracker_pslist()
-             WHERE Pid = PID
-           })
+         LET Netstat <= memoize(
+             name='netstat',
+             key='Pid',
+             period=NetstatCachePeriod,
+             query={
+               SELECT *
+               FROM Artifact.Linux.Network.NetstatEnriched()
+             })
 
-       LET InstallDeps = SELECT *
-         FROM if(
-           condition=InstallNethogs,
-           then={
-             SELECT *
-             FROM Artifact.Linux.Utils.InstallDeb(DebName='nethogs')
-           })
+         LET Result = SELECT *
+           FROM foreach(
+             row={
+               SELECT *
+               FROM Hoggers
+             },
+             query={
+               SELECT *
+               FROM foreach(
+                 row={
+                   SELECT 
+                          dict(
+                            Timestamp=Timestamp,
+                            Process=Process,
+                            PID=PID,
+                            UID=UID,
+                            Sent=Sent,
+                            Recv=Recv,
+                            ProcInfo=dict(
+                              CommandLine=NULL,
+                              Username=NULL,
+                              StartTime=NULL)) + (get(
+                              item=Netstat,
+                              field=PID) || dict(
+                              Name=NULL,
+                              Laddr=NULL,
+                              Lport=NULL,
+                              Raddr=NULL,
+                              Rport=NULL,
+                              Status=NULL,
+                              ProcInfo=dict(),
+                              CallChain=NULL,
+                              ChildrenTree=NULL)) AS Contents
+                   FROM scope()
+                   WHERE Contents
+                 },
+                 column='Contents')
+             })
 
-       SELECT *
-       FROM chain(a_install=InstallDeps,
-                  b_result=Result)
+         // Leverage the InstallDeb utility to do the actual package install:
+         LET InstallDeps = SELECT *
+           FROM if(
+             condition=InstallNethogs,
+             then={
+               SELECT *
+               FROM Artifact.Linux.Utils.InstallDeb(DebName='nethogs')
+             })
+
+         SELECT *
+         FROM chain(a_install=InstallDeps,
+                    b_result=Result)
+
+      notebook:
+        - type: vql
+          name: Traffic
+          template: |
+            /*
+            # Network traffic
+
+            {{ $TimeRange := Query "SELECT min(item=Timestamp) AS StartTime, max(item=Timestamp) AS EndTime FROM source() GROUP BY 1" | Expand }}
+            Network traffic (in bytes per second) between {{ Get $TimeRange "0.StartTime" }}
+            and {{ Get $TimeRange "0.EndTime" }}
+            */
+            LET ColumnTypes = dict(
+                _ChildrenTree='tree')
+
+            SELECT 
+                   Timestamp,
+                   PID,
+                   ProcInfo.Name || Process AS Name,
+                   ProcInfo.CommandLine AS CmdLine,
+                   ProcInfo.Username AS Username,
+                   ProcInfo.StartTime AS StartTime,
+                   Laddr,
+                   Lport,
+                   Raddr,
+                   Rport,
+                   Status,
+                   humanize(
+                     bytes=Sent * 1024) AS Sent,
+                   humanize(
+                     bytes=Recv * 1024) AS Recv,
+                   ProcInfo AS _ProcInfo,
+                   CallChain AS _CalLChain,
+                   ChildrenTree AS _ChildrenTree
+            FROM source()
+            LIMIT 50
+
+        - type: vql_suggestion
+          name: Total traffic
+          template: |
+            /*
+            # Network traffic summary
+
+            {{ $TimeRange := Query "SELECT min(item=Timestamp) AS StartTime, max(item=Timestamp) AS EndTime FROM source() GROUP BY 1" | Expand }}
+            This is a **rough estimate** of the total bytes sent and received between
+            {{ Get $TimeRange "0.StartTime" }} and {{ Get $TimeRange "0.EndTime" }}.
+            */
+            LET Summary = SELECT 
+                     PID,
+                     ProcInfo.Name || Process AS Name,
+                     ProcInfo.CommandLine AS CommandLine,
+                     ProcInfo.Username AS Username,
+                     ProcInfo.StartTime AS StartTime,
+                     // nethogs -t outputs a data rate every second. Adding these
+                     // values give us a rough estimate of the data transferred
+                     sum(
+                       item=Sent * 1024) AS Sent,
+                     sum(
+                       item=Recv * 1024) AS Recv
+              FROM source()
+              GROUP BY PID
+
+            SELECT *,
+                   humanize(
+                     bytes=Sent) AS Sent,
+                   humanize(
+                     bytes=Recv) AS Recv,
+                   humanize(
+                     bytes=Recv + Sent) AS Total
+            FROM Summary
+            LIMIT 50
+
+        - type: vql_suggestion
+          name: Plot traffic for PID
+          template: |
+            // The process whose traffic to plot (PID 0 here happens to be "Unknown traffic"
+            // from nethogs):
+            LET PIDTarget = 0
+
+            /*
+            {{ $Vars := Query "SELECT PIDTarget, min(item=Timestamp) AS StartTime, max(item=Timestamp) AS EndTime FROM source() GROUP BY 1" | Expand }}
+            # Network traffic for PID {{ Get $Vars "0.PIDTarget" }}
+
+            Network traffic (in bytes per second) between {{ Get $Vars "0.StartTime" }}
+            and {{ Get $Vars "0.EndTime" }}
+            */
+            LET SinglePSStats = SELECT 
+                                       Timestamp.Unix AS Timestamp,
+                                       Sent * 1024 AS Sent,
+                                       Recv * 1024 AS Recv
+              FROM source()
+              WHERE PID = PIDTarget
+              LIMIT 50
+
+            /*
+            {{ Query "SELECT * FROM SinglePSStats" | TimeChart }}
+            */
+
+            // We do not really need this, but we need to execute some VQL
+            // in order for the plot to appear:
+            SELECT *
+            FROM SinglePSStats

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -5,16 +5,25 @@ description: |
   list all processes that produces (non-local) network traffic on the client,
   leveraging the process tracker, and displays the total bytes received and sent
   in the given time frame.
-  
+
   Note that the tool/package "nethogs" needs to be installed before calling this
-  artifact.
+  artifact. Set the parameter InstallNethogs to true in order to automatically
+  install the package and its dependencies (Debian-based systems only).
+
+  Short-lived processes that only run for less than one second will not be shown
+  unless a process tracker is installed on the system (*.Events.TrackProcesses).
 
 parameters:
+  - name: InstallNethogs
+    description: Install nethogs using apt-get
+    type: bool
+    default: false
+
   - name: Duration
     type: integer
     description: Number of seconds to monitor processes
     default: 300
-    
+
 precondition:
   SELECT * FROM info() where OS = 'linux'
 
@@ -22,7 +31,7 @@ sources:
     - query: |
        LET Hoggers <= SELECT Process,
                              PID,
-                             UID,
+                             int(int=UID) AS UID,
                              humanize(bytes=parse_float(string=Sent) * 1024) AS Sent,
                              humanize(
                                bytes=parse_float(
@@ -30,7 +39,7 @@ sources:
          FROM query(
            timeout=Duration,
            query={
-             SELECT 
+             SELECT
                     Process,
                     PID,
                     UID,
@@ -53,23 +62,38 @@ sources:
            })
          GROUP BY Process
 
+       LET Result = SELECT *
+         FROM foreach(
+           row={
+             SELECT *
+             FROM Hoggers
+           },
+           query={
+             SELECT
+                    int(int=PID) AS PID,
+                    Name,
+                    CommandLine,
+                    Cwd,
+                    Username,
+                    StartTime,
+                    if(
+                      condition=EndTime.Unix < 0,
+                      then=NULL,
+                      else=EndTime) AS EndTime,
+                    Sent,
+                    Recv
+             FROM process_tracker_pslist()
+             WHERE Pid = PID
+           })
+
+       LET InstallDeps = SELECT *
+         FROM if(
+           condition=InstallNethogs,
+           then={
+             SELECT *
+             FROM Artifact.Linux.Utils.InstallDeb(DebName='nethogs')
+           })
+
        SELECT *
-       FROM foreach(
-         row={
-           SELECT *
-           FROM Hoggers
-         },
-         query={
-           SELECT 
-                  Pid,
-                  Name,
-                  CommandLine,
-                  Cwd,
-                  Username,
-                  StartTime,
-                  EndTime,
-                  Sent,
-                  Recv
-           FROM process_tracker_pslist()
-           WHERE Pid = PID
-         })
+       FROM chain(a_install=InstallDeps,
+                  b_result=Result)

--- a/content/exchange/artifacts/Linux.Network.Nethogs.yaml
+++ b/content/exchange/artifacts/Linux.Network.Nethogs.yaml
@@ -70,7 +70,7 @@ sources:
                FROM foreach(
                  row={
                    SELECT *
-                   FROM execve(argv=['/usr/sbin/nethogs', '-t'],
+                   FROM execve(argv=['/usr/sbin/nethogs', '-t', '-C'],
                                length=10000,
                                sep='\n\nRefreshing:\n')
                  },
@@ -207,7 +207,7 @@ sources:
                      sum(
                        item=Recv * 1024) AS Recv
               FROM source()
-              GROUP BY PID
+              GROUP BY PID, Name
 
             SELECT *,
                    humanize(
@@ -222,9 +222,8 @@ sources:
         - type: vql_suggestion
           name: Plot traffic for PID
           template: |
-            // The process whose traffic to plot (PID 0 here happens to be "Unknown traffic"
-            // from nethogs):
-            LET PIDTarget = 0
+            // The process whose traffic to plot:
+            LET PIDTarget = 1234
 
             /*
             {{ $Vars := Query "SELECT PIDTarget, min(item=Timestamp) AS StartTime, max(item=Timestamp) AS EndTime FROM source() GROUP BY 1" | Expand }}


### PR DESCRIPTION
The nethogs artifacts had a number of issues. This rewrite contains the following changes:

- Optionally auto-install nethogs using apt-get (very easy with the new Linux.Utils.InstallDeb artifact)
- Correctly handle floating-point values
- Use data rate instead of volume: byte/s is more useful than rows of accumulating byte sent/received
- Do not evaluate `process_tracker_pslist()` for every row – use `memoize()`
- Use the NetstatEnriched artifact instead of the process tracker
- "left-join" the enriched data, avoiding data loss if a PID cannot be enriched
- Present the final result with human-readable numbers and hand-picked columns
- Add a VQL suggestion calculating a rough estimate of the total traffic
- Add a VQL suggestion for plotting a single process' traffic
- Use the StartTime and EndTime variables when calling `source()`, but add boilerplate LET expressions so that the user can easily override the time range
- Add support for UDP
- Include the "Unknown TCP"/"Unknown UDP" results