### PR TITLE
Update Windows.Audit.CISCat_Lite artifact

### DIFF
--- a/content/exchange/artifacts/Windows.Audit.CISCat_Lite.yaml
+++ b/content/exchange/artifacts/Windows.Audit.CISCat_Lite.yaml
@@ -43,7 +43,8 @@ sources:
           
       -- Run the command     
       LET _ <= SELECT *
-        FROM execve(argv=[CISCatPath, "-b", BaselinePath, '-p', ProfileName])
+        FROM Artifact.Windows.System.PowerShell(Command=format(format='& "%v" -b %v -p "%v"', 
+                                                args=[CISCatPath, BaselinePath, ProfileName]))
 
       SELECT * 
          FROM foreach( row={


### PR DESCRIPTION
Windows.Audit.CISCat_Lite artifact has a problematic `execve` command which doesn't properly execute in cases where CISCatPath has spaces in file path. I solved the problem by executing via PowerShell artifact instead of `execve`, it properly executes now.