### PR TITLE
Update Windows.Forensics.Jumplists_JLECmd artifact

### DIFF
--- a/content/exchange/artifacts/Windows.Forensics.Jumplists_JLECmd.yaml
+++ b/content/exchange/artifacts/Windows.Forensics.Jumplists_JLECmd.yaml
@@ -48,7 +48,7 @@ sources:
       -- decompress utility
       LET payload = SELECT *
         FROM unzip(filename=jlecmdpackage[0].FullPath,
-            output_directory=tmpdir)
+            output_directory=tmpdir) WHERE OriginalPath =~ "JLECmd.exe"
 
       -- execute payload
       LET deploy <= SELECT *


### PR DESCRIPTION
Artifact was trying to execute .dll file instead of .exe so I added a condition in unzip command to ensure selecting .exe file.