### PR TITLE
Update Windows.EventLog.Hayabusa

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -12,10 +12,10 @@ description: |
 author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity, Fukusuke Takahashi - @fukusuket
 
 tools:
- - name: Hayabusa-3.0.1
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.0.1/hayabusa-3.0.1-win-x64-live-response.zip
-   expected_hash: 10cbcfc0bfd2dd21abd47d0fb00cb5ff1a244fa90e7fe4564a8dc98aa07ce5d1
-   version: 3.0.1
+ - name: Hayabusa-3.1.0
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.1.0/hayabusa-3.1.0-win-x64-live-response.zip
+   expected_hash: 73cd86b70ebbd4983e2c1c5553276b58034436e18ac64967f996aeeeab60a89b
+   version: 3.1.0
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -111,7 +111,7 @@ sources:
    query: |
         -- Fetch the binary
         LET Toolzip <= SELECT FullPath
-        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-3.0.1", IsExecutable=FALSE)
+        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-3.1.0", IsExecutable=FALSE)
 
         LET TmpDir <= tempdir()
 
@@ -119,7 +119,7 @@ sources:
         LET _ <= SELECT *
         FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
 
-        LET HayabusaExe <= TmpDir + '\\hayabusa-3.0.1-win-x64.exe'
+        LET HayabusaExe <= TmpDir + '\\hayabusa-3.1.0-win-x64.exe'
 
         -- Optionally update the rules
         LET _ <= if(condition=UpdateRules, then={


### PR DESCRIPTION
Hello :)
Our team released [Hayabusa 3.1.0](https://github.com/Yamato-Security/hayabusa/releases/tag/v3.1.0), so I'll update Hayabusa Artifact.

Thank you for your time.