### PR TITLE
Fix Windows.EventLog.Hayabusa sort option

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -73,7 +73,7 @@ parameters:
    description: "Update rules before scanning"
    type: bool
    default: Y
- - name: SortEvents
+ - name: Sort
    description: "Sort events before saving the file"
    type: bool
    default: N
@@ -141,7 +141,7 @@ sources:
           "--" + OutputTimeFormat,
           "--threads", str(str=Threads),
           if(condition=OutputFormat = "jsonl", then="-L"),
-          if(condition=SortEvents, then="--sort-events"),
+          if(condition=Sort, then="--sort"),
           if(condition=NoisyRules, then="--enable-noisy-rules"),
           if(condition=EIDFilter, then="--eid-filter"),
           if(condition=TimeOffset, then="--time-offset"),           if(condition=TimeOffset, then=TimeOffset),


### PR DESCRIPTION
Sorry for bothering you again. The sort option was renamed in version 3.1.0, so I fixed it.

Thank you for your time.