### PR TITLE
Update honeyfiles

### DIFF
--- a/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
+++ b/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
@@ -30,7 +30,7 @@ parameters:
      default: "."
 sources:
   - precondition:
-        SELECT OS From info() WHERE OS = 'linux'
+        SELECT OS From info() where OS = 'linux' AND version(plugin="watch_ebpf") >= 0
 
     query: |
        LET RandomChars(size) = SELECT
@@ -134,12 +134,20 @@ sources:
            Timestamp,
            System.ProcessID AS Pid,
            EventData.pathname AS FileName,
-           IsHoneyFile,
            process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
            join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
-                sep="->") AS CallChain
+                sep="->") AS CallChain,
+           (System.ProcessID+EventData.pathname) as DedupKey
          FROM AuditEvents
          WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
        
-       SELECT *
-       FROM delay(query=Track, delay=5)
+       SELECT 
+         Timestamp,
+         Pid,
+         FileName,
+         ProcInfo,
+         CallChain 
+       FROM dedup(query={
+          SELECT *,
+          FROM delay(query=Track, delay=5)
+       },key="DedupKey",timeout=2)

--- a/content/exchange/artifacts/Windows.Detection.Honeyfile.yaml
+++ b/content/exchange/artifacts/Windows.Detection.Honeyfile.yaml
@@ -34,85 +34,87 @@ parameters:
     description: User name regex that will be used to host honeyfiles.
     type: string
     default: "."
+export: |
+   LET RandomChars(size) = SELECT
+       format(format="%02x", args=rand(range=256)) AS HexByte
+     FROM range(end=size)
+   
+   LET check_exist(path) = SELECT
+       OSPath,
+       Size,
+       IsDir,
+       if(condition=read_file(filename=OSPath)[-7:] =~ 'VRHoney',
+          then=True,
+          else=False) AS IsHoneyFile
+     FROM stat(filename=path)
+   
+   LET enumerate_path = SELECT
+       regex_replace(source=TargetPath,
+                     re='''\%USERPROFILE\%''',
+                     replace=Directory) AS TargetPath,
+       *,
+       check_exist(path=regex_replace(source=TargetPath,
+                                      re='''\%USERPROFILE\%''',
+                                      replace=Directory))[0] AS Exists,
+       MaxSize - rand(range=(MaxSize - MinSize)) - len(
+         list=unhex(string=MagicBytes)) - 7 AS _PaddingSize
+     FROM Honeyfiles
+   
+   LET target_users = SELECT Name,
+                             Directory,
+                             UUID
+     FROM Artifact.Windows.Sys.Users()
+     WHERE NOT UUID =~ '''^(S-1-5-18|S-1-5-19|S-1-5-20)$'''
+      AND Name =~ HoneyUserRegex
+   
+   LET show_honeyfiles = SELECT TargetPath,
+                                Enabled,
+                                MagicBytes,
+                                MinSize,
+                                MaxSize,
+                                _PaddingSize,
+                                Exists.Size AS Size,
+                                Exists.IsHoneyFile AS IsHoneyFile
+     FROM foreach(row=target_users, query=enumerate_path)
+   
+   LET copy_honeyfiles = SELECT
+       *,
+       if(condition=Enabled =~ "^(Y|YES)$"
+           AND (NOT Size OR IsHoneyFile),
+          then=log(message="Creating file %v", dedup=-1, args=TargetPath)
+           && copy(dest=TargetPath,
+                   create_directories='y',
+                   accessor='data',
+                   filename=unhex(
+                     string=MagicBytes + join(
+                       array=RandomChars(size=_PaddingSize).HexByte) +
+                       format(format='%x', args='VRHoney'))),
+          else="File does not exist") AS CreateHoneyFile
+     FROM show_honeyfiles
+   
+   LET remove_honeyfiles = SELECT
+       *, _PaddingSize,
+       if(condition=IsHoneyFile,
+          then=log(message="Removing %v", args=TargetPath, dedup=-1)
+           && rm(filename=TargetPath),
+          else="File does not exist") AS RemoveHoneyFile
+     FROM show_honeyfiles
+   
+   LET add_honeyfiles = SELECT
+       TargetPath,
+       Enabled,
+       MagicBytes,
+       MinSize,
+       MaxSize,
+       check_exist(path=TargetPath)[0].Size AS Size,
+       check_exist(path=TargetPath)[0].IsHoneyFile AS IsHoneyFile
+     FROM copy_honeyfiles
+
 sources:
   - precondition:
       SELECT OS From info() where OS = 'windows' AND version(plugin="dedup") >= 0
 
     query: |
-       LET RandomChars(size) = SELECT
-           format(format="%02x", args=rand(range=256)) AS HexByte
-         FROM range(end=size)
-       
-       LET check_exist(path) = SELECT
-           OSPath,
-           Size,
-           IsDir,
-           if(condition=read_file(filename=OSPath)[-7:] =~ 'VRHoney',
-              then=True,
-              else=False) AS IsHoneyFile
-         FROM stat(filename=path)
-       
-       LET enumerate_path = SELECT
-           regex_replace(source=TargetPath,
-                         re='''\%USERPROFILE\%''',
-                         replace=Directory) AS TargetPath,
-           *,
-           check_exist(path=regex_replace(source=TargetPath,
-                                          re='''\%USERPROFILE\%''',
-                                          replace=Directory))[0] AS Exists,
-           MaxSize - rand(range=(MaxSize - MinSize)) - len(
-             list=unhex(string=MagicBytes)) - 7 AS _PaddingSize
-         FROM Honeyfiles
-       
-       LET target_users = SELECT Name,
-                                 Directory,
-                                 UUID
-         FROM Artifact.Windows.Sys.Users()
-         WHERE NOT UUID =~ '''^(S-1-5-18|S-1-5-19|S-1-5-20)$'''
-          AND Name =~ HoneyUserRegex
-       
-       LET show_honeyfiles = SELECT TargetPath,
-                                    Enabled,
-                                    MagicBytes,
-                                    MinSize,
-                                    MaxSize,
-                                    _PaddingSize,
-                                    Exists.Size AS Size,
-                                    Exists.IsHoneyFile AS IsHoneyFile
-         FROM foreach(row=target_users, query=enumerate_path)
-       
-       LET copy_honeyfiles = SELECT
-           *, if(condition=Enabled =~ "^(Y|YES)$"
-                  AND (NOT Size OR IsHoneyFile),
-                 then=log(message="Creating file %v", dedup=-1, args=TargetPath)
-                  && copy(dest=TargetPath,
-                          create_directories='y',
-                          accessor='data',
-                          filename=unhex(
-                            string=MagicBytes + join(
-                              array=RandomChars(size=_PaddingSize).HexByte) +
-                              format(format='%x', args='VRHoney'))),
-                 else="File does not exist") AS CreateHoneyFile
-         FROM show_honeyfiles
-       
-       LET remove_honeyfiles = SELECT
-           *, _PaddingSize,
-           if(condition=IsHoneyFile,
-              then=log(message="Removing %v", args=TargetPath, dedup=-1)
-               && rm(filename=TargetPath),
-              else="File does not exist") AS RemoveHoneyFile
-         FROM show_honeyfiles
-       
-       LET add_honeyfiles = SELECT
-           TargetPath,
-           Enabled,
-           MagicBytes,
-           MinSize,
-           MaxSize,
-           check_exist(path=TargetPath)[0].Size AS Size,
-           check_exist(path=TargetPath)[0].IsHoneyFile AS IsHoneyFile
-         FROM copy_honeyfiles
-       
        LET _ <= atexit(query={ SELECT * FROM remove_honeyfiles })
        
        LET WatchFiles <= to_dict(item={
@@ -147,146 +149,79 @@ sources:
            process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
            join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
                 sep="->") AS CallChain,
-           (System.ProcessID+EventData.FileName) as DedupKey
+           (System.ProcessID + EventData.FileName) AS DedupKey
          FROM AuditEvents
          WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
        
-       SELECT 
-         Timestamp,
-         Pid,
-         TargetPath,
-         ProcInfo,
-         CallChain 
+       SELECT Timestamp,
+              Pid,
+              TargetPath,
+              ProcInfo,
+              CallChain
        FROM dedup(query={
-          SELECT *,
-          FROM delay(query=Events, delay=5)
-       },key="DedupKey",timeout=2)
+           SELECT *
+           FROM delay(query=Events, delay=5)
+         },
+                  key="DedupKey",
+                  timeout=2)
+
    
   - precondition:
       SELECT OS From info() where OS = 'windows' AND version(plugin="dedup") = NULL
       
     query: |
-       LET RandomChars(size) = SELECT format(format="%02x", args=rand(range=256)) AS HexByte
-       FROM range(end=size)
-       
-       LET check_exist(path) = SELECT
-           OSPath,
-           Size,
-           IsDir,
-           if(condition=read_file(filename=OSPath)[-7:] =~ 'VRHoney',
-              then=True,
-              else=False) AS IsHoneyFile
-         FROM stat(filename=path)
-       
-       LET enumerate_path = SELECT
-           regex_replace(source=TargetPath,
-                         re='''\%USERPROFILE\%''',
-                         replace=Directory) AS TargetPath,
-           *,
-           check_exist(path=regex_replace(source=TargetPath,
-                                          re='''\%USERPROFILE\%''',
-                                          replace=Directory))[0] AS Exists,
-           MaxSize - rand(range=(MaxSize - MinSize)) - len(
-             list=unhex(string=MagicBytes)) - 7 AS _PaddingSize
-         FROM Honeyfiles
-       
-       LET target_users = SELECT Name,
-                                 Directory,
-                                 UUID
-         FROM Artifact.Windows.Sys.Users()
-         WHERE NOT UUID =~ '''^(S-1-5-18|S-1-5-19|S-1-5-20)$'''
-          AND Name =~ HoneyUserRegex
-       
-       LET show_honeyfiles = SELECT TargetPath,
-                                    Enabled,
-                                    MagicBytes,
-                                    MinSize,
-                                    MaxSize,
-                                    _PaddingSize,
-                                    Exists.Size AS Size,
-                                    Exists.IsHoneyFile AS IsHoneyFile
-         FROM foreach(row=target_users, query=enumerate_path)
-       
-       LET copy_honeyfiles = SELECT
-           *, if(condition=Enabled =~ "^(Y|YES)$"
-                  AND (NOT Size OR IsHoneyFile),
-                 then=log(message="Creating file %v", dedup=-1, args=TargetPath)
-                  && copy(dest=TargetPath,
-                          create_directories='y',
-                          accessor='data',
-                          filename=unhex(
-                            string=MagicBytes + join(
-                              array=RandomChars(size=_PaddingSize).HexByte) +
-                              format(format='%x', args='VRHoney'))),
-                 else="File does not exist") AS CreateHoneyFile
-         FROM show_honeyfiles
-       
-       LET remove_honeyfiles = SELECT
-           *, _PaddingSize,
-           if(condition=IsHoneyFile,
-              then=log(message="Removing %v", args=TargetPath, dedup=-1)
-               && rm(filename=TargetPath),
-              else="File does not exist") AS RemoveHoneyFile
-         FROM show_honeyfiles
-       
-       LET add_honeyfiles = SELECT
-           TargetPath,
-           Enabled,
-           MagicBytes,
-           MinSize,
-           MaxSize,
-           check_exist(path=TargetPath)[0].Size AS Size,
-           check_exist(path=TargetPath)[0].IsHoneyFile AS IsHoneyFile
-         FROM copy_honeyfiles
-       
        LET _ <= atexit(query={ SELECT * FROM remove_honeyfiles })
        
-       LET KernelVolumes <= SELECT 
-            *,
-           regex_replace(
-             source=Name,
-             replace='',
-             re="^\\\\GLOBAL\\?\\?\\\\") AS UserDrive,
-           regex_replace(
-             source=SymlinkTarget,
-             replace='',
-             re="^\\\\Device\\\\") AS KernelDrive
+       LET KernelVolumes <= SELECT *,
+                                   regex_replace(source=Name,
+                                                 replace='',
+                                                 re="^\\\\GLOBAL\\?\\?\\\\") AS UserDrive,
+                                   regex_replace(
+                                     source=SymlinkTarget,
+                                     replace='',
+                                     re="^\\\\Device\\\\") AS KernelDrive
          FROM winobj()
-        WHERE SymlinkTarget =~ "Volume"
+         WHERE SymlinkTarget =~ "Volume"
           AND Name =~ "[a-z]:$"
-          
+       
        LET WatchFiles <= to_dict(
            item={
-             SELECT 
-                    KernelPath AS _key,
-                    IsHoneyFile AS _value
-             FROM foreach(
-               row=KernelVolumes,
-               query={
-                 SELECT *,
-                        regex_replace(
-                          source=TargetPath,
-                          replace=SymlinkTarget,
-                          re="[A-Z]+\:") AS KernelPath
-                 FROM add_honeyfiles
-                 WHERE TargetPath =~ UserDrive
-               })
-           })
+           SELECT
+           KernelPath AS _key,
+           IsHoneyFile AS _value
+           FROM foreach(
+             row=KernelVolumes,
+             query={
+           SELECT
+           *,
+           regex_replace(
+             source=TargetPath,
+             replace=SymlinkTarget,
+             re="[A-Z]+\:") AS KernelPath
+           FROM add_honeyfiles
+           WHERE TargetPath =~ UserDrive
+         })
+         })
        
        LET Keyword <= 5264
        
        LET CurrentPid <= getpid()
        
-       LET TargetEvents = SELECT *
-         FROM watch_etw(guid='{edd08927-9cc4-4e65-b970-c2560fb5c289}',
-                        description="Microsoft-Windows-Kernel-File",
-                        any=Keyword)
+       LET TargetEvents = SELECT
+           *
+         FROM watch_etw(
+           guid='{edd08927-9cc4-4e65-b970-c2560fb5c289}',
+           description="Microsoft-Windows-Kernel-File",
+           any=Keyword)
          WHERE System.ID = 12
           AND System.ProcessID != CurrentPid
        
        LET AuditEvents = SELECT
-           timestamp(string=System.TimeStamp) AS Timestamp,
-           get(item=WatchFiles, field=EventData.FileName) AS IsHoneyFile,
+           timestamp(
+             string=System.TimeStamp) AS Timestamp,
+           get(
+             item=WatchFiles,
+             field=EventData.FileName) AS IsHoneyFile,
            *
          FROM TargetEvents
          WHERE IsHoneyFile != NULL
@@ -296,11 +231,17 @@ sources:
            IsHoneyFile,
            System.ProcessID AS Pid,
            EventData.FileName AS TargetPath,
-           process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
-           join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
-                sep="->") AS CallChain
+           process_tracker_get(
+             id=System.ProcessID).Data AS ProcInfo,
+           join(
+             array=process_tracker_callchain(
+               id=System.ProcessID).Data.Name,
+             sep="->") AS CallChain
          FROM AuditEvents
          WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
        
-        SELECT *
-          FROM delay(query=Events, delay=5)
+       SELECT
+           *
+       FROM delay(
+         query=Events,
+         delay=5)

--- a/content/exchange/artifacts/Windows.Detection.Honeyfile.yaml
+++ b/content/exchange/artifacts/Windows.Detection.Honeyfile.yaml
@@ -36,7 +36,7 @@ parameters:
     default: "."
 sources:
   - precondition:
-      SELECT OS From info() where OS = 'windows'
+      SELECT OS From info() where OS = 'windows' AND version(plugin="dedup") >= 0
 
     query: |
        LET RandomChars(size) = SELECT
@@ -142,6 +142,157 @@ sources:
        
        LET Events = SELECT
            Timestamp,
+           System.ProcessID AS Pid,
+           EventData.FileName AS TargetPath,
+           process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
+           join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
+                sep="->") AS CallChain,
+           (System.ProcessID+EventData.FileName) as DedupKey
+         FROM AuditEvents
+         WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
+       
+       SELECT 
+         Timestamp,
+         Pid,
+         TargetPath,
+         ProcInfo,
+         CallChain 
+       FROM dedup(query={
+          SELECT *,
+          FROM delay(query=Events, delay=5)
+       },key="DedupKey",timeout=2)
+   
+  - precondition:
+      SELECT OS From info() where OS = 'windows' AND version(plugin="dedup") = NULL
+      
+    query: |
+       LET RandomChars(size) = SELECT format(format="%02x", args=rand(range=256)) AS HexByte
+       FROM range(end=size)
+       
+       LET check_exist(path) = SELECT
+           OSPath,
+           Size,
+           IsDir,
+           if(condition=read_file(filename=OSPath)[-7:] =~ 'VRHoney',
+              then=True,
+              else=False) AS IsHoneyFile
+         FROM stat(filename=path)
+       
+       LET enumerate_path = SELECT
+           regex_replace(source=TargetPath,
+                         re='''\%USERPROFILE\%''',
+                         replace=Directory) AS TargetPath,
+           *,
+           check_exist(path=regex_replace(source=TargetPath,
+                                          re='''\%USERPROFILE\%''',
+                                          replace=Directory))[0] AS Exists,
+           MaxSize - rand(range=(MaxSize - MinSize)) - len(
+             list=unhex(string=MagicBytes)) - 7 AS _PaddingSize
+         FROM Honeyfiles
+       
+       LET target_users = SELECT Name,
+                                 Directory,
+                                 UUID
+         FROM Artifact.Windows.Sys.Users()
+         WHERE NOT UUID =~ '''^(S-1-5-18|S-1-5-19|S-1-5-20)$'''
+          AND Name =~ HoneyUserRegex
+       
+       LET show_honeyfiles = SELECT TargetPath,
+                                    Enabled,
+                                    MagicBytes,
+                                    MinSize,
+                                    MaxSize,
+                                    _PaddingSize,
+                                    Exists.Size AS Size,
+                                    Exists.IsHoneyFile AS IsHoneyFile
+         FROM foreach(row=target_users, query=enumerate_path)
+       
+       LET copy_honeyfiles = SELECT
+           *, if(condition=Enabled =~ "^(Y|YES)$"
+                  AND (NOT Size OR IsHoneyFile),
+                 then=log(message="Creating file %v", dedup=-1, args=TargetPath)
+                  && copy(dest=TargetPath,
+                          create_directories='y',
+                          accessor='data',
+                          filename=unhex(
+                            string=MagicBytes + join(
+                              array=RandomChars(size=_PaddingSize).HexByte) +
+                              format(format='%x', args='VRHoney'))),
+                 else="File does not exist") AS CreateHoneyFile
+         FROM show_honeyfiles
+       
+       LET remove_honeyfiles = SELECT
+           *, _PaddingSize,
+           if(condition=IsHoneyFile,
+              then=log(message="Removing %v", args=TargetPath, dedup=-1)
+               && rm(filename=TargetPath),
+              else="File does not exist") AS RemoveHoneyFile
+         FROM show_honeyfiles
+       
+       LET add_honeyfiles = SELECT
+           TargetPath,
+           Enabled,
+           MagicBytes,
+           MinSize,
+           MaxSize,
+           check_exist(path=TargetPath)[0].Size AS Size,
+           check_exist(path=TargetPath)[0].IsHoneyFile AS IsHoneyFile
+         FROM copy_honeyfiles
+       
+       LET _ <= atexit(query={ SELECT * FROM remove_honeyfiles })
+       
+       LET KernelVolumes <= SELECT 
+            *,
+           regex_replace(
+             source=Name,
+             replace='',
+             re="^\\\\GLOBAL\\?\\?\\\\") AS UserDrive,
+           regex_replace(
+             source=SymlinkTarget,
+             replace='',
+             re="^\\\\Device\\\\") AS KernelDrive
+         FROM winobj()
+        WHERE SymlinkTarget =~ "Volume"
+          AND Name =~ "[a-z]:$"
+          
+       LET WatchFiles <= to_dict(
+           item={
+             SELECT 
+                    KernelPath AS _key,
+                    IsHoneyFile AS _value
+             FROM foreach(
+               row=KernelVolumes,
+               query={
+                 SELECT *,
+                        regex_replace(
+                          source=TargetPath,
+                          replace=SymlinkTarget,
+                          re="[A-Z]+\:") AS KernelPath
+                 FROM add_honeyfiles
+                 WHERE TargetPath =~ UserDrive
+               })
+           })
+       
+       LET Keyword <= 5264
+       
+       LET CurrentPid <= getpid()
+       
+       LET TargetEvents = SELECT *
+         FROM watch_etw(guid='{edd08927-9cc4-4e65-b970-c2560fb5c289}',
+                        description="Microsoft-Windows-Kernel-File",
+                        any=Keyword)
+         WHERE System.ID = 12
+          AND System.ProcessID != CurrentPid
+       
+       LET AuditEvents = SELECT
+           timestamp(string=System.TimeStamp) AS Timestamp,
+           get(item=WatchFiles, field=EventData.FileName) AS IsHoneyFile,
+           *
+         FROM TargetEvents
+         WHERE IsHoneyFile != NULL
+       
+       LET Events = SELECT
+           Timestamp,
            IsHoneyFile,
            System.ProcessID AS Pid,
            EventData.FileName AS TargetPath,
@@ -151,5 +302,5 @@ sources:
          FROM AuditEvents
          WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
        
-       SELECT *
-       FROM delay(query=Events, delay=5)
+        SELECT *
+          FROM delay(query=Events, delay=5)


### PR DESCRIPTION
Update preconditions and add dedup() for both Linux.Detection.Honeyfiles and Windows.Detection.Honeyfiles. Make Windows.Detection.Honeyfiles backwards compatible. 