### PR TITLE
adding capability to process windows evtx files with hayabusa server side, via event monitoring

### DIFF
--- a/content/exchange/artifacts/Server.Monitor.Flows.Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Server.Monitor.Flows.Windows.EventLogs.Hayabusa.yaml
@@ -1,0 +1,52 @@
+name: Server.Monitor.Flows.Windows.EventLogs.Hayabusa
+author: Whitney Champion - bluesky @whit.zip, Eric Capuano - bluesky @eric.zip
+description: |
+   This server monitoring artifact will automatically collect any KAPE triage artifacts, and send them for processing with Hayabusa.
+
+type: SERVER_EVENT
+
+parameters:
+ - name: ArtifactNameRegex
+   default: "Windows.KapeFiles.Targets"
+   description: A regular expression to select which artifacts to upload
+ - name: VelociraptorDataDir
+   default:
+
+sources:
+ - name: Process
+   query: |
+
+    -- Get flow completions for hunt/collection
+    LET completions = SELECT *, client_info(client_id=ClientId).os_info.fqdn AS Fqdn 
+        FROM watch_monitoring(artifact="System.Flow.Completion")
+        WHERE Flow.artifacts_with_results =~ ArtifactNameRegex
+        
+    -- Get flows and file data for each flow 
+    LET flows = SELECT * FROM foreach(
+        row=completions, 
+        query={
+            SELECT ClientId, *, Data["VFSPath"] AS VFSPath FROM enumerate_flow(client_id=ClientId, flow_id=FlowId) LIMIT 1
+        }
+    )
+    
+    -- Get location of evtx files to send to hayabusa 
+    LET evtx_files = SELECT * FROM foreach(
+        row=flows,
+        query={
+            SELECT ClientId, OSPath FROM stat(filename=VFSPath, accessor="fs") WHERE OSPath =~ ".evtx" LIMIT 1
+        }
+    )
+    
+    -- Get directory
+    LET directories = SELECT ClientId, parse_string_with_regex(string=OSPath, regex='fs:((/clients/[^/]+/collections/[^/]+/uploads/auto/C:/Windows/System32/winevt/)[^/]+/)') AS Directory FROM evtx_files
+    
+    -- Replace C: with C%3A to make the path correct
+    LET full_paths = SELECT ClientId, regex_replace(source=Directory.g1, re='C:',replace='C%3A') as Path FROM directories
+    
+    -- Send the directory of evtx files to Hayabusa
+    SELECT * FROM foreach(
+        row=full_paths,
+        query={
+            SELECT * FROM Artifact.Server.Process.Windows.EventLogs.Hayabusa(EvtxDirectory=VelociraptorDataDir + Path, ClientId=ClientId)
+        }
+    )

--- a/content/exchange/artifacts/Server.Process.Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Server.Process.Windows.EventLogs.Hayabusa.yaml
@@ -1,0 +1,168 @@
+name: Server.Process.Windows.EventLogs.Hayabusa
+author: Whitney Champion - bluesky @whit.zip, Eric Capuano - bluesky @eric.zip
+description: |
+    Process evtx files server side with Hayabusa
+
+type: SERVER
+
+tools:
+ - name: Hayabusa-Linux-3.3.0
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.3.0/hayabusa-3.3.0-lin-x64-musl.zip
+   expected_hash: c0c4429e25b70694f477be5ac74f5a1e115eb3611b4ebec076b6c23ef3d07d70
+   version: 3.3.0
+
+parameters:
+ - name: EvtxDirectory
+   description: "Directory of .evtx files"
+   default: 
+ - name: ClientId
+   default: 
+ - name: MinimalLevel
+   description: "Minimum level for rules"
+   default: medium
+   type: choices
+   choices:
+     - informational
+     - low
+     - medium
+     - high
+     - critical
+ - name: OutputFormat
+   description: "Choose the format of the result file"
+   default: csv
+   type: choices
+   choices:
+     - csv
+     - jsonl
+ - name: OutputProfile
+   description: "Decide how much data you want back"
+   default: standard
+   type: choices
+   choices:
+     - minimal
+     - standard
+     - verbose
+     - all-field-info
+     - all-field-info-verbose
+     - super-verbose
+     - timesketch-minimal
+     - timesketch-verbose
+ - name: OutputTimeFormat
+   description: "Choose the format of timestamp"
+   default: ISO-8601
+   type: choices
+   choices:
+     - European-time
+     - ISO-8601
+     - RFC-2822
+     - RFC-3339
+     - US-military-time
+     - US-time
+     - UTC
+ - name: Threads
+   description: "Number of threads"
+   type: int
+   default: 4
+ - name: UpdateRules
+   description: "Update rules before scanning"
+   type: bool
+   default: Y
+ - name: Sort
+   description: "Sort events before saving the file"
+   type: bool
+   default: N
+ - name: NoisyRules
+   description: "Enable rules marked as noisy"
+   type: bool
+   default: N
+ - name: EIDFilter
+   description: "Scan only common Event IDs for quicker scans"
+   type: bool
+   default: N
+ - name: TimeOffset
+   description: "Scan recent events based on an offset (ex: 1y, 3M, 30d, 24h, 30m)"
+ - name: TimelineStart
+   description: "Start time of the event logs to load (ex: '2020-02-22 00:00:00 +09:00')"
+ - name: TimelineEnd
+   description: "End time of the event logs to load (ex: '2022-02-22 23:59:59 +09:00')"
+ - name: ExcludeCategory
+   description: "Do not load rules with specified logsource categories (ex: process_creation,pipe_created)"
+ - name: ExcludeEID
+   description: "Do not scan specific EIDs for faster speed (ex: 1) (ex: 1,4688)"
+ - name: ExcludeStatus
+   description: "Do not load rules according to status (ex: experimental) (ex: stable,test)"
+ - name: ExcludeTag
+   description: "Do not load rules with specific tags (ex: sysmon)"
+ - name: IncludeCategory
+   description: "Only load rules with specified logsource categories (ex: process_creation,pipe_created)"
+ - name: IncludeEID
+   description: "Scan only specified EIDs for faster speed (ex: 1) (ex: 1,4688)"
+ - name: IncludeTag
+   description: "Only load rules with specific tags (ex: attack.execution,attack.discovery)"
+
+
+sources:
+ - name: HayabusaProcessing
+   query: |
+   
+        -- Fetch the binary
+        LET Toolzip <= SELECT FullPath
+        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-Linux-3.3.0", IsExecutable=FALSE)
+
+        LET TmpDir <= tempdir()
+
+        -- Unzip the binary
+        LET _ <= SELECT *
+        FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
+
+        LET HayabusaBin <= TmpDir + '/hayabusa-3.3.0-lin-x64-musl'
+
+        -- Optionally update the rules
+        LET _ <= if(condition=UpdateRules, then={
+        SELECT * FROM execve(argv=[HayabusaBin, 'update-rules'], cwd=TmpDir) })
+
+        LET HayabusaCmd <= if(condition=OutputFormat = "csv", then="csv-timeline", else="json-timeline")
+        LET ResultFile <= TmpDir + '/hayabusa_results.' + OutputFormat
+
+        -- Build the command line considering all options
+        LET cmdline <= filter(list=(
+          HayabusaBin, HayabusaCmd,
+          "--no-wizard", 
+          "--quiet", "--no-summary",
+          "--directory", EvtxDirectory, 
+          "--output", ResultFile,
+          "--min-level", MinimalLevel,
+          "--profile", OutputProfile,
+          "--" + OutputTimeFormat,
+          "--threads", str(str=Threads),
+          if(condition=OutputFormat = "jsonl", then="-L"),
+          if(condition=Sort, then="--sort"),
+          if(condition=NoisyRules, then="--enable-noisy-rules"),
+          if(condition=EIDFilter, then="--eid-filter"),
+          if(condition=TimeOffset, then="--time-offset"),           if(condition=TimeOffset, then=TimeOffset),
+          if(condition=TimelineStart, then="--timeline-start"),     if(condition=TimelineStart, then=TimelineStart),
+          if(condition=TimelineEnd, then="--timeline-end"),         if(condition=TimelineEnd, then=TimelineEnd),
+          if(condition=ExcludeCategory, then="--exclude-category"), if(condition=ExcludeCategory, then=ExcludeCategory),
+          if(condition=ExcludeEID, then="--exclude-eid"),           if(condition=ExcludeEID, then=ExcludeEID),
+          if(condition=ExcludeStatus, then="--exclude-status"),     if(condition=ExcludeStatus, then=ExcludeStatus),
+          if(condition=ExcludeTag, then="--exclude-tag"),           if(condition=ExcludeTag, then=ExcludeTag),
+          if(condition=IncludeCategory, then="--include-category"), if(condition=IncludeCategory, then=IncludeCategory),
+          if(condition=IncludeEID, then="--include-eid"),           if(condition=IncludeEID, then=IncludeEID),
+          if(condition=IncludeTag, then="--include-tag"),           if(condition=IncludeTag, then=IncludeTag),
+        ), regex=".+")
+
+        -- Run the tool and divert messages to logs.
+        LET ExecHB <= SELECT *
+        FROM execve(argv=cmdline, cwd=TmpDir, sep="\n", length=9999999)
+        WHERE log(message=Stdout)
+
+        -- Upload the raw file.
+        LET Upload <= SELECT upload(file=ResultFile) AS Uploads FROM scope()
+
+        -- Parse the result file based on the output format
+        LET CSV_RESULT  = SELECT * FROM parse_csv(filename=ResultFile)
+        LET JSONL_RESULT = SELECT * FROM parse_jsonl(filename=ResultFile)
+        LET s = scope()
+        
+        SELECT ClientId, timestamp(string=s.Timestamp || s.datetime) AS EventTime, *
+        FROM if(condition= OutputFormat = "csv", then=CSV_RESULT, else=JSONL_RESULT)


### PR DESCRIPTION
adding capability to process windows evtx files with hayabusa server side, via event monitoring

one artifact gets added to server event monitoring table and calls the hayabusa server side artifact when a completed flow matches the artifact regex provided