### PR TITLE
client monitoring artifacts for process creation and high privileged logons

### DIFF
--- a/content/exchange/artifacts/Generic.Events.Processes.yaml
+++ b/content/exchange/artifacts/Generic.Events.Processes.yaml
@@ -1,0 +1,22 @@
+name: Generic.Events.Processes
+author: Herbert Bärschneider, SEC Consult
+description: |
+  This artifact is meant for monitoring processes on clients. It is usable on every operating system supported by Velociraptor.
+  It periodically queries the existing processes and emits lines for differences (new processes and missing/removed ones).
+  Processes are tracked and compared based on the following elements: process ID, parent process ID, SID of the process owner, username, process name, executable associated with the process, commandline of the process
+
+type: CLIENT_EVENT
+
+parameters:
+  - name: Period
+    default: 2
+    type: int
+    description: how many seconds the artifact waits between checking processes for changes
+
+sources:
+   - query: |
+       LET RunningProcesses = SELECT *, format(format="%v %v %v %v %v %v %v", args=[Pid, Ppid, OwnerSid, Username, Name, Exe, CommandLine]) AS DiffKey FROM pslist()
+     
+       LET EventQuery = SELECT * FROM diff(query=RunningProcesses, period=Period, key="DiffKey")
+     
+       SELECT * FROM EventQuery

--- a/content/exchange/artifacts/Windows.Events.ETWProcesses.yaml
+++ b/content/exchange/artifacts/Windows.Events.ETWProcesses.yaml
@@ -1,0 +1,15 @@
+name: Windows.Events.ETWProcesses
+author: Herbert Bärschneider, SEC Consult
+description: |
+  This artifact is meant for monitoring processes on Windows clients. 
+  It uses Kernel ETW providers to notice process creations and terminations.
+  
+  Requirements:
+  - Velociraptor Client and Velociraptor Server need version v0.74 or newer (or else the feature is just not supported and won't work at all)
+
+type: CLIENT_EVENT
+
+sources:
+   - query: |
+       SELECT *, atoi(string=EventData.ProcessId) AS Pid, atoi(string=EventData.ParentId) AS Ppid 
+       FROM watch_etw(guid='kernel', kernel_tracer_type=['process'])

--- a/content/exchange/artifacts/Windows.Events.HighPrivilegedLogon.yaml
+++ b/content/exchange/artifacts/Windows.Events.HighPrivilegedLogon.yaml
@@ -1,0 +1,42 @@
+name: Windows.Events.HighPrivilegedLogon
+author: Herbert Bärschneider, SEC Consult
+description: |
+ Artifact to detect logons that get special privileges assigned. The artifact monitors for security event id 4672.
+ This is useful to see where accounts with high privileges are being actively used.
+ 
+ Be aware, there is lots of noise from NT_AUTHORITY\SYSTEM and the machine account of a system. These are filtered out for you.
+
+type: CLIENT_EVENT
+
+parameters:
+ - name: eventLog
+   default: C:\Windows\system32\winevt\logs\Security.evtx
+ - name: PrivilegesRegex
+   type: regex
+   description: Regex for the privileges you care about
+
+sources:
+ - precondition:
+     SELECT OS From info() where OS = 'windows'
+   query: |
+     LET files = SELECT * FROM glob(globs=eventLog)
+     
+     SELECT timestamp(epoch=System.TimeCreated.SystemTime) As EventTime,
+             System.EventRecordID as EventRecordID,
+             System.EventID.Value as EventID,
+             System.Computer as SourceComputer,
+             EventData.SubjectUserName as SubjectUserName,
+             EventData.PrivilegeList as PrivilegeList,
+             System,
+             EventData,
+             Message
+       FROM foreach(
+         row=files,
+         async=TRUE,
+         query={
+           SELECT *
+           FROM watch_evtx(filename=OSPath)
+           WHERE System.EventID.Value = 4672
+             AND EventData.PrivilegeList =~ PrivilegesRegex
+             AND NOT ((EventData.SubjectUserName =~ "SYSTEM" AND EventData.SubjectDomainName =~ "NT AUTHORITY") OR EventData.SubjectUserName =~ "\$$")
+       })


### PR DESCRIPTION
Hi,

at the blog post https://sec-consult.com/blog/detail/c2-powered-by-dinosaurs/, three Velo artifacts for Client Monitoring were published. I saw that these were not yet added to the Artifact Exchange, so I want to remedy this.

Two artifacts add further options for process creation monitoring on clients, one via ETW on Windows, another based on the generic VQL plugin "pslist".
The third artifact allows monitoring for logins on Windows systems that are assigned high privileges.

I think these artifacts could be good additions for monitoring activity while investigating an active cyber attack with Velociraptor.

Kind Regards