### PR TITLE
Update Windows.EventLog.Hayabusa

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -12,10 +12,10 @@ description: |
 author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity, Fukusuke Takahashi - @fukusuket
 
 tools:
- - name: Hayabusa-3.3.0
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.3.0/hayabusa-3.3.0-win-x64-live-response.zip
-   expected_hash: acac87725334a09ebe2eb4a7cc467a844878434d403e353def52aacbb020c4d6
-   version: 3.3.0
+ - name: Hayabusa-3.4.0
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.4.0/hayabusa-3.4.0-win-x64-live-response.zip
+   expected_hash: db0fdbad217fd7afe75a010b29805302d31ea77a3ac4a73cefd6b41c710c75fe
+   version: 3.4.0
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -111,7 +111,7 @@ sources:
    query: |
         -- Fetch the binary
         LET Toolzip <= SELECT FullPath
-        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-3.3.0", IsExecutable=FALSE)
+        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-3.4.0", IsExecutable=FALSE)
 
         LET TmpDir <= tempdir()
 
@@ -119,7 +119,7 @@ sources:
         LET _ <= SELECT *
         FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
 
-        LET HayabusaExe <= TmpDir + '\\hayabusa-3.3.0-win-x64.exe'
+        LET HayabusaExe <= TmpDir + '\\hayabusa-3.4.0-win-x64.exe'
 
         -- Optionally update the rules
         LET _ <= if(condition=UpdateRules, then={


### PR DESCRIPTION
Hi @scudette :)
Our team released [Hayabusa 3.4.0](https://github.com/Yamato-Security/hayabusa/releases/tag/v3.4.0), so I'll update Hayabusa Artifact.

Thank you so much for your time.