### PR TITLE
Add Linux.Network.Netstat.Watcher artifact

### DIFF
--- a/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
+++ b/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
@@ -4,7 +4,8 @@ author: Antonio Blescia (TheThMando)
 description: >
     Collects a one-time snapshot of current non-LISTEN remote connections and a continuous diff stream of added/removed/changed connections. Loopback destinations are excluded by default (127.0.0.1 and ::1) via a configurable regex. 
     The sampling interval (SampleIntervalSec) and the overall monitoring window (MonitorDurationSec) are fully parameterized. Each record includes process metadata via process_tracker_get
-
+implied_permissions:
+  - IMPERSONATION
 parameters:
   - name: SampleIntervalSec
     description: Sampling interval in seconds used by diff() while monitoring connections.

--- a/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
+++ b/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
@@ -1,5 +1,5 @@
 name: Linux.Network.Netstat.Watcher
-type: CLIENT
+type: CLIENT_EVENT
 author: Antonio Blescia (TheThMando)
 description: >
     Collects a one-time snapshot of current non-LISTEN remote connections and a continuous diff stream of added/removed/changed connections. Loopback destinations are excluded by default (127.0.0.1 and ::1) via a configurable regex. 

--- a/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
+++ b/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
@@ -1,11 +1,9 @@
 name: Linux.Network.Netstat.Watcher
-type: CLIENT_EVENT
+type: CLIENT
 author: Antonio Blescia (TheThMando)
 description: >
     Collects a one-time snapshot of current non-LISTEN remote connections and a continuous diff stream of added/removed/changed connections. Loopback destinations are excluded by default (127.0.0.1 and ::1) via a configurable regex. 
     The sampling interval (SampleIntervalSec) and the overall monitoring window (MonitorDurationSec) are fully parameterized. Each record includes process metadata via process_tracker_get
-required_permissions:
-  - IMPERSONATION
 
 parameters:
   - name: SampleIntervalSec

--- a/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
+++ b/content/exchange/artifacts/Linux.Network.Netstat.Watcher.yaml
@@ -1,0 +1,72 @@
+name: Linux.Network.Netstat.Watcher
+type: CLIENT
+author: Antonio Blescia (TheThMando)
+description: >
+    Collects a one-time snapshot of current non-LISTEN remote connections and a continuous diff stream of added/removed/changed connections. Loopback destinations are excluded by default (127.0.0.1 and ::1) via a configurable regex. 
+    The sampling interval (SampleIntervalSec) and the overall monitoring window (MonitorDurationSec) are fully parameterized. Each record includes process metadata via process_tracker_get
+required_permissions:
+  - IMPERSONATION
+
+parameters:
+  - name: SampleIntervalSec
+    description: Sampling interval in seconds used by diff() while monitoring connections.
+    type: int
+    default: 60
+  - name: MonitorDurationSec
+    type: int
+    description: Total monitoring window in seconds; the outer query stops after this duration.
+    default: 600
+  - name: ExcludeRemoteIPsRegex
+    type: regex
+    description: Regex of remote IPs to exclude (matched against Raddr.IP).
+    default: '127.0.0.1|::1'
+
+sources:
+  - name: RemoteConnectionsSnapshot
+    query: |
+       SELECT timestamp(epoch=now()) AS now_utc,
+              Pid,
+              Status,
+              FamilyString,
+              Laddr,
+              Raddr,
+              process_tracker_get(id=Pid) AS ProcInfo
+       FROM netstat()
+       WHERE Status != "LISTEN"
+        and NOT Raddr.IP =~ ExcludeRemoteIPsRegex
+
+
+  - name: RemoteConnectionsDiffMonitor
+    query: |
+       SELECT *
+       FROM query(query={
+           SELECT timestamp(epoch=now()) AS now_utc,
+                  Diff,
+                  Timestamp,
+                  Pid,
+                  Status,
+                  FamilyString,
+                  Laddr,
+                  Raddr,
+                  process_tracker_get(id=Pid) AS ProcInfo
+           FROM diff(query={
+           SELECT Timestamp,
+                  Pid,
+                  Status,
+                  FamilyString,
+                  Laddr,
+                  Raddr,
+                  format(format="%d|%s|%s|%s:%d|%s:%d",
+                         args=[Pid, L3, L4, Laddr.IP, Laddr.Port,
+                           Raddr.IP, Raddr.Port]) AS DiffKey
+           FROM netstat()
+           WHERE Status != "LISTEN"
+            and NOT Raddr.IP =~ ExcludeRemoteIPsRegex
+         },
+                     key="DiffKey",
+                     period=SampleIntervalSec)
+           WHERE Diff =~ "added|removed|changed"
+         },
+                  env=dict(SampleIntervalSec=SampleIntervalSec,
+                           ExcludeRemoteIPsRegex=ExcludeRemoteIPsRegex),
+                  timeout=MonitorDurationSec)


### PR DESCRIPTION
Reading one of the latest analyses by Group-IB on the threat actor UNC2891 [(https://www.group-ib.com/blog/unc2891-bank-heist/),](https://www.group-ib.com/blog/unc2891-bank-heist/) I thought of creating an artifact that collects a one-time snapshot of current non-LISTEN remote connections and a continuous diff stream of added/removed/changed connections.

It is very useful for monitoring the connections that occur within a time period set as a parameter.

