### PR TITLE
Update Windows.Detection.Honeyfile.yaml

### DIFF
--- a/content/exchange/artifacts/Windows.Detection.Honeyfile.yaml
+++ b/content/exchange/artifacts/Windows.Detection.Honeyfile.yaml
@@ -78,18 +78,17 @@ export: |
      FROM foreach(row=target_users, query=enumerate_path)
    
    LET copy_honeyfiles = SELECT
-       *,
-       if(condition=Enabled =~ "^(Y|YES)$"
-           AND (NOT Size OR IsHoneyFile),
-          then=log(message="Creating file %v", dedup=-1, args=TargetPath)
-           && copy(dest=TargetPath,
-                   create_directories='y',
-                   accessor='data',
-                   filename=unhex(
-                     string=MagicBytes + join(
-                       array=RandomChars(size=_PaddingSize).HexByte) +
-                       format(format='%x', args='VRHoney'))),
-          else="File does not exist") AS CreateHoneyFile
+       *, if(condition=Enabled =~ "^(Y|YES)$"
+              AND (NOT Size OR IsHoneyFile),
+             then=log(message="Creating file %v", dedup=-1, args=TargetPath)
+              && copy(dest=TargetPath,
+                      create_directories='y',
+                      accessor='data',
+                      filename=unhex(
+                        string=MagicBytes + join(
+                          array=RandomChars(size=_PaddingSize).HexByte) +
+                          format(format='%x', args='VRHoney'))),
+             else="File does not exist") AS CreateHoneyFile
      FROM show_honeyfiles
    
    LET remove_honeyfiles = SELECT
@@ -109,6 +108,12 @@ export: |
        check_exist(path=TargetPath)[0].Size AS Size,
        check_exist(path=TargetPath)[0].IsHoneyFile AS IsHoneyFile
      FROM copy_honeyfiles
+   
+   LET ThreadInfo(tPid, tTid) = SELECT filename,
+                                       memory_basic_info.RegionSize
+     FROM threads(pid=tPid)
+     WHERE tid = tTid
+     LIMIT 1
 
 sources:
   - precondition:
@@ -146,6 +151,7 @@ sources:
            Timestamp,
            System.ProcessID AS Pid,
            EventData.FileName AS TargetPath,
+           atoi(string=EventData.IssuingThreadId) AS Tid,
            process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
            join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
                 sep="->") AS CallChain,
@@ -157,7 +163,9 @@ sources:
               Pid,
               TargetPath,
               ProcInfo,
-              CallChain
+              CallChain,
+              Tid,
+              ThreadInfo(tPid=Pid, tTid=Tid)[0] AS ThreadDetails
        FROM dedup(query={
            SELECT *
            FROM delay(query=Events, delay=5)
@@ -165,39 +173,31 @@ sources:
                   key="DedupKey",
                   timeout=2)
 
-   
   - precondition:
       SELECT OS From info() where OS = 'windows' AND version(plugin="dedup") = NULL
       
     query: |
        LET _ <= atexit(query={ SELECT * FROM remove_honeyfiles })
        
-       LET KernelVolumes <= SELECT *,
-                                   regex_replace(source=Name,
-                                                 replace='',
-                                                 re="^\\\\GLOBAL\\?\\?\\\\") AS UserDrive,
-                                   regex_replace(
-                                     source=SymlinkTarget,
+       LET KernelVolumes <= SELECT *, regex_replace(
+                                     source=Name,
                                      replace='',
-                                     re="^\\\\Device\\\\") AS KernelDrive
+                                     re="^\\\\GLOBAL\\?\\?\\\\") AS UserDrive,
+                                   regex_replace(source=SymlinkTarget,
+                                                 replace='',
+                                                 re="^\\\\Device\\\\") AS KernelDrive
          FROM winobj()
          WHERE SymlinkTarget =~ "Volume"
           AND Name =~ "[a-z]:$"
        
-       LET WatchFiles <= to_dict(
-           item={
-           SELECT
-           KernelPath AS _key,
-           IsHoneyFile AS _value
-           FROM foreach(
-             row=KernelVolumes,
-             query={
-           SELECT
-           *,
-           regex_replace(
-             source=TargetPath,
-             replace=SymlinkTarget,
-             re="[A-Z]+\:") AS KernelPath
+       LET WatchFiles <= to_dict(item={
+           SELECT KernelPath AS _key,
+                  IsHoneyFile AS _value
+           FROM foreach(row=KernelVolumes,
+                        query={
+           SELECT *, regex_replace(source=TargetPath,
+                                   replace=SymlinkTarget,
+                                   re="[A-Z]+\:") AS KernelPath
            FROM add_honeyfiles
            WHERE TargetPath =~ UserDrive
          })
@@ -207,21 +207,16 @@ sources:
        
        LET CurrentPid <= getpid()
        
-       LET TargetEvents = SELECT
-           *
-         FROM watch_etw(
-           guid='{edd08927-9cc4-4e65-b970-c2560fb5c289}',
-           description="Microsoft-Windows-Kernel-File",
-           any=Keyword)
+       LET TargetEvents = SELECT *
+         FROM watch_etw(guid='{edd08927-9cc4-4e65-b970-c2560fb5c289}',
+                        description="Microsoft-Windows-Kernel-File",
+                        any=Keyword)
          WHERE System.ID = 12
           AND System.ProcessID != CurrentPid
        
        LET AuditEvents = SELECT
-           timestamp(
-             string=System.TimeStamp) AS Timestamp,
-           get(
-             item=WatchFiles,
-             field=EventData.FileName) AS IsHoneyFile,
+           timestamp(string=System.TimeStamp) AS Timestamp,
+           get(item=WatchFiles, field=EventData.FileName) AS IsHoneyFile,
            *
          FROM TargetEvents
          WHERE IsHoneyFile != NULL
@@ -231,17 +226,13 @@ sources:
            IsHoneyFile,
            System.ProcessID AS Pid,
            EventData.FileName AS TargetPath,
-           process_tracker_get(
-             id=System.ProcessID).Data AS ProcInfo,
-           join(
-             array=process_tracker_callchain(
-               id=System.ProcessID).Data.Name,
-             sep="->") AS CallChain
+           atoi(string=EventData.IssuingThreadId) AS Tid,
+           ThreadInfo(tPid=Pid, tTid=Tid)[0] AS ThreadDetails,
+           process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
+           join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
+                sep="->") AS CallChain
          FROM AuditEvents
          WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
        
-       SELECT
-           *
-       FROM delay(
-         query=Events,
-         delay=5)
+       SELECT *
+       FROM delay(query=Events, delay=5)


### PR DESCRIPTION
This update to Windows.Detection.Honeyfile captures thread information (including the filename, and memory region size). Injected processes using common C2 frameworks (Sliver, Cobalt Strike) will often return an empty filename for the thread which accessed the honey file, since it will not be backed by disk, which has proven a useful in distinguishing false positives. 