### PR TITLE
Create Windows.Memory.Mem2Disk artifact

### DIFF
--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -121,6 +121,7 @@ sources:
     -- Checks the offsets
     LET OffsetsTmp <= dict()
 
+    -- TODO: integrate the OneByteOffset comparison into here
     LET CheckOffsetsHelper(X, Y) = SELECT 
         atoi(string=format(format="0x%x", args=substr(str=X, start=_value, end=AddressLength+_value)))
           - atoi(string=format(format="0x%x", args=substr(str=Y, start=_value, end=AddressLength+_value))) AS Difference
@@ -159,7 +160,7 @@ sources:
       FROM range(end=len(list=X), step=2)
       WHERE set(item=Tmp,
                 field="a",
-                value=if(condition=Eq  AND Tmp.a < 2, then=0, else=Tmp.a + 1))
+                value=if(condition=Eq AND Tmp.a < 2, then=0, else=Tmp.a + 1))
        AND Tmp.a > 2
       LIMIT 1
     

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -8,13 +8,16 @@ description: |
     on the target system(s).
     See also https://github.com/lautarolecumberry/DetectingFilelessMalware
 
+    (Ignored) False Positives
+    - `ASLR`:       If jumps or comparisons are not relative and Address Space Layout Randomization
+                    (ASLR) is enabled, then addresses within these jumps are adjusted in RAM
+                    with a constant offset. This offset can be computed and ignored.
+    - `BaseOfData`: Relative Virtual Adresses (RVA) cause an offset in the code in memory of a
+                    32-bit process. This is the case when the field BaseOfData is set.
+                    Like ASLR it is a constant offset that is added to addresses.
+
+
 parameters:
-- name: IgnoreOneByteOffsets
-  description: Relative Virtual Adresses (RVA) cause an offset in the code in memory of a process.
-               This is the case when the field BaseOfData is set to 0x8000. It creates false
-               positives and is fairly safe to ignore (1-byte injections are really hard).
-  default: True
-  type: bool
 - name: UploadFindings
   description: Upload all executables where code in memory does not match code on disk. This
                can potentially generate a lot of traffic. Dry-run before enabling this option.
@@ -25,8 +28,11 @@ parameters:
   default: .
 - name: ModuleRegEx
   type: regex
-  description: Filter for modules to check.
-  default: "(KERNELBASE|ntdll).dll|.exe"
+  description: Filter for modules to check. If you want to scan all modules (i.e. libraries) within
+               a binary, replace with `.*`. The default parameter checks the original binary itself (.exe)
+               as well as kernelbase.dll, ntdll.dll, user32.dll, kernel32.dll, shell32.dll, msvcrt.dll,
+               advapi32.dll, and comdlg32.dll (i.e. commonly injected libraries).
+  default: ".*\\.exe|(KERNELBASE|ntdll|user32|kenrel32|shell32|msvcrt|advapi32|comdlg32)\\.dll"
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -63,8 +69,8 @@ sources:
                                   DriveReplace(Path=MappingName) AS Path
       FROM vad(pid=Pid)
       WHERE MappingName
-       AND Protection =~ "xr-"
-            AND MappingName =~ ModuleRegEx
+      AND Protection =~ "xr-"
+      AND MappingName =~ ModuleRegEx
       LIMIT 1
     
     LET GetTextSegment(Path) = filter(condition="x=>x.Name = '.text'",
@@ -78,7 +84,8 @@ sources:
       FROM InfoFromVad(Pid=Pid)
       WHERE Address != 0
       AND TextSegmentData.FileOffset
-    
+
+    -- helper function for formating
     LET Hex(X) = format(format="%#x", args=X)
 
     LET Int64(X) = parse_binary(profile="",
@@ -90,7 +97,7 @@ sources:
     LET GetContent(Pid, Name) = SELECT
         *, Name,
         Address AS MemAddress,
-        Hex(X=Address - TextSegmentData.VMA) AS ASLR, 
+        Hex(X=Address - TextSegmentData.VMA) AS ASLR, --calculate ASLR offset to later filter it out
         read_file(accessor="process",
                   offset=Address,
                   filename=PidFilename,
@@ -113,8 +120,10 @@ sources:
       FROM GetContent(Pid=Pid, Name=Name)
       WHERE NOT Comparison
 
+    -- parameter for start PAGESIZE; compare 1 MB pages first
     LET PAGESIZE <= 1024 * 1024
 
+    -- helper function for comparisons of PAGESIZE
     LET _CompareRegions(Base, X, Y, PAGESIZE) = SELECT
         _value + Base AS Offset,
         X[_value:(_value + PAGESIZE)] AS XInt,
@@ -122,71 +131,75 @@ sources:
       FROM range(end=len(list=X), step=PAGESIZE)
       WHERE XInt != YInt
 
+    -- compare full pages (to speed up comparison)
+    -- for each 1 MB page which does not match
+    -- compare 4096 B page
+    -- for each 4096 B page which does not match
+    -- compare single integers
     LET CompareRegions(X, Y, IntSize) = SELECT
         Offset,
         Hex(X=XInt) AS X,
         Hex(X=YInt) AS Y,
         Hex(X=Int64(X=XInt) - Int64(X=YInt)) AS Difference
       FROM foreach(row={
+        -- 1 MB pages
         SELECT *
         FROM _CompareRegions(Base=0, X=X, Y=Y, PAGESIZE=PAGESIZE)
       },
-                  query={
+      query={
         SELECT *
         FROM foreach(row={
-        SELECT *
-        FROM _CompareRegions(Base=Offset, X=XInt, Y=YInt, PAGESIZE=4096)
-      },
-                    query={
-        SELECT *
-        FROM _CompareRegions(Base=Offset, X=XInt, Y=YInt, PAGESIZE=IntSize)
-      })
+          -- 4096 B pages
+          SELECT *
+          FROM _CompareRegions(Base=Offset, X=XInt, Y=YInt, PAGESIZE=4096)
+        },
+        query={
+          -- single integers
+          SELECT *
+          FROM _CompareRegions(Base=Offset, X=XInt, Y=YInt, PAGESIZE=IntSize)
+        })
       })
       LIMIT 500
 
+    -- check if offsets between X and Y (i.e. RAM and disk) are
+    -- always the same offset. Then it is ASLR or BaseOfData.
     LET CompareUniqueRegions(X, Y, IntSize, ASLR) = SELECT *
       FROM CompareRegions(X=X, Y=Y, IntSize=IntSize)
-      WHERE Difference != ASLR
+      WHERE Difference != ASLR --filter out ASLR
       GROUP BY Difference
 
     -- compare the executable from memory and hard disk
     -- only print the ones where they do not match
-    LET Compare(Pid, Name, IntSize) = if(
-        condition=log(message="Comparing process %v", args=Pid)
-        AND IgnoreOneByteOffsets,
-        then={
-        SELECT Pid,
-              Name,
-              ASLR,
-              IntSize,
-              PidFilename,
-              Path,
-              {
-        SELECT Offset,
-              X AS MemoryValue,
-              Y AS DiskValue,
-              Difference,
-              Hex(X=ASLR) AS ASLR
-        FROM CompareUniqueRegions(X=MemoryData, Y=DiskData, IntSize=IntSize, ASLR=ASLR)
-        } AS Differences,
-              MemAddress,
-              DiskAddress,
-              SegmentSize
-        FROM FilterContent(Pid=Pid, Name=Name)
-        WHERE NOT OneByteOffset
-      },
-        else={
-        SELECT Pid,
-              Name,
-              ASLR,
-              IntSize,
-              PidFilename,
-              Path,
-              MemAddress,
-              DiskAddress,
-              SegmentSize
-        FROM FilterContent(Pid=Pid, Name=Name)
-      })
+    LET Compare(Pid, Name, IntSize) = 
+      SELECT Pid,
+             Name,
+             ASLR,
+             IntSize,
+             PidFilename,
+             Path,
+             {
+               SELECT Offset,
+                      X AS MemoryValue,
+                      Y AS DiskValue,
+                      Difference,
+                      ASLR
+               FROM CompareUniqueRegions(X=MemoryData, Y=DiskData, IntSize=IntSize, ASLR=ASLR)
+               -- filter out BaseOfData by shifting the binary value
+               -- to the correct position (256 = shift by 1 byte)
+               WHERE int(int=Difference) / 256 != int(int=ASLR)
+               AND int(int=Difference) / 256 / 256 != int(int=ASLR)
+               AND int(int=Difference) / 256 / 256 / 256 != int(int=ASLR)
+               AND int(int=Difference) * 256 != int(int=ASLR)
+               AND int(int=Difference) * 256 * 256 != int(int=ASLR)
+               AND int(int=Difference) * 256 * 256 * 256 != int(int=ASLR)
+             } AS Differences,
+             MemAddress,
+             DiskAddress,
+             SegmentSize
+      FROM FilterContent(Pid=Pid, Name=Name)
+      WHERE log(message="Comparing process %v - %v", args=[Pid, Name])
+            AND Differences -- filter processes with no differences other than ASLR offsets
+            --FIXME: AND (len(list=Differences) != 1 AND IntSize=4) -- filter out BaseOfData and ignore one constant offset
 
     -- compare with uploading the suspicious executables
     LET CompareAndUpload(Pid, Name, IntSize) = SELECT
@@ -215,15 +228,15 @@ sources:
     SELECT *
     FROM foreach(row=GetPids,
                 workers=20,
-                query={
+      query={
         SELECT *
         FROM if(condition=UploadFindings,
-                then={
+      then={
         SELECT *
         FROM CompareAndUpload(Pid=Pid, Name=Name, IntSize=IntSize)
       },
-                else={
+      else={
         SELECT *
         FROM Compare(Pid=Pid, Name=Name, IntSize=IntSize)
       })
-      })
+    })

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -6,6 +6,7 @@ description: |
     happens legitimately and is mostly used by malware.
     This check is executed without dumping the memory and works live
     on the target system(s).
+    See also https://github.com/lautarolecumberry/DetectingFilelessMalware
 
 parameters:
 - name: IgnoreOneByteOffsets
@@ -19,132 +20,224 @@ parameters:
                can potentially generate a lot of traffic. Dry-run before enabling this option.
   default: False
   type: bool
+- name: ProcessNameFilter
+  type: regex
+  default: .*
+- name: AddressLength
+  type: int
+  default: 8
+  description: Length of the address/architecture (e.g. 8 for x64, 4 for x86)
 
 precondition: SELECT OS From info() where OS = 'windows'
+
+export: |
+  -- These functions help to resolve the Kernel Device Filenames
+  -- into a regular filename with drive letter.
+  LET DriveReplaceLookup <= SELECT
+      split(sep_string="\\", string=Name)[-1] AS Drive,
+      upcase(string=SymlinkTarget) AS Target,
+      len(list=SymlinkTarget) AS Len
+    FROM winobj()
+    WHERE Name =~ "^\\\\GLOBAL\\?\\?\\\\.:"
+  
+  LET _DriveReplace(Path) = SELECT Drive + Path[Len:] AS ResolvedPath
+    FROM DriveReplaceLookup
+    WHERE upcase(string=Path[:Len]) = Target
+  
+  LET DriveReplace(Path) = _DriveReplace(Path=Path)[0].ResolvedPath ||
+      Path
 
 sources:
 - query: |
     -- get all processes
-    LET GetPids =
-      SELECT Pid, Username
+    LET GetPids = SELECT Pid,
+                         Name,
+                         Username
       FROM pslist()
-
+      WHERE Name =~ ProcessNameFilter
+    
     -- get all memory pages for a certain pid
-    LET InfoFromVad = 
-      SELECT 
-        atoi(string="0x"+split(string=AddressRange, sep="-")[0]) as Address,
-        filter(list=ProcessChain, regex=Pid)[0].Exe as Path
-      FROM Artifact.Windows.System.VAD(PidRegex=str(str=Pid))
+    LET InfoFromVad(Pid) = SELECT Address,
+                                  Size,
+                                  DriveReplace(Path=MappingName) AS Path
+      FROM vad(pid=Pid)
       WHERE MappingName
-        AND Protection =~ "xr-"
-        AND MappingName =~ "(exe)$"
-
+       AND Protection =~ "xr-"
+            AND MappingName =~ "(exe)$"
+      LIMIT 1
+    
+    LET GetTextSegment(Path) = filter(condition="x=>x.Name = '.text'",
+                                      list=parse_pe(file=Path).Sections)[0]
+    
     -- parse the executable (PE) from memory (specifically, the text segment)
-    LET GetMetadata =
-      SELECT Path,
+    LET GetMetadata(Pid, Name) = SELECT
+        Path,
+        str(str=Pid) AS PidFilename,
         Address,
-        parse_pe(file=Path).Sections[0] AS TextSegmentData
-      FROM InfoFromVad
+        GetTextSegment(Path=Path) AS TextSegmentData
+      FROM InfoFromVad(Pid=Pid)
       WHERE Address != 0
-
+       AND TextSegmentData.FileOffset
+    
+    LET Hex(X) = format(format="%#x", args=X)
+    
     -- read the executable from memory and hard disk
-    LET GetContent =
-      SELECT *,
-        format(format="%#x", args=Address) AS MemAddress,
-        format(format="%x",
-          args=read_file(accessor="process",
-            offset=Address,
-            filename=format(format="/%d", args=Pid),
-            length=TextSegmentData.Size)
-          ) AS MemoryData,
-        hash(path=format(format="/%d", args=Pid),
-            accessor="process",
-            hashselect="SHA256"
-          ).SHA256 AS MemorySHA256,
-        format(format="%#x", args=TextSegmentData.FileOffset) AS DiskAddress,
-        format(format="%x",
-          args=read_file(accessor="file",
-            offset=TextSegmentData.FileOffset,
-            filename=Path,
-            length=TextSegmentData.Size)
-          ) AS DiskData,
-        hash(path=Path,
-          accessor="file",
-          hashselect="SHA256"
-        ).SHA256 AS DiskSHA256
-      FROM GetMetadata
-      WHERE len(list=MemoryData) != 0
-        AND len(list=DiskData) != 0
-
+    LET GetContent(Pid, Name) = SELECT *, Address AS MemAddress,
+                                       read_file(
+                                         accessor="process",
+                                         offset=Address,
+                                         filename=PidFilename,
+                                         length=TextSegmentData.Size) AS MemoryData,
+                                       hash(
+                                         path=PidFilename,
+                                         accessor="process",
+                                         hashselect="SHA256").SHA256 AS MemorySHA256,
+                                       TextSegmentData.FileOffset AS DiskAddress,
+                                       TextSegmentData.Size AS SegmentSize,
+                                       read_file(
+                                         accessor="file",
+                                         offset=TextSegmentData.FileOffset,
+                                         filename=Path,
+                                         length=TextSegmentData.Size) AS DiskData,
+                                       hash(
+                                         path=Path,
+                                         accessor="file",
+                                         hashselect="SHA256").SHA256 AS DiskSHA256
+      FROM GetMetadata(
+        Name=Name,
+        Pid=Pid)
+      WHERE MemoryData
+       AND log(
+             dedup=-1,
+             message="Inspecting Pid %v (%v): %#x-%#x vs %#x-%#x",
+             args=[Pid, Name, Address, Address + SegmentSize,
+               DiskAddress, DiskAddress + SegmentSize])
+    
     -- Filter out not needed comparisons early
-    LET FilterContent =
-      SELECT *, MemoryData = DiskData AS Comparison
-      FROM GetContent
+    LET FilterContent(Pid, Name) = SELECT *, MemoryData = DiskData AS Comparison
+      FROM GetContent(Pid=Pid, Name=Name)
       WHERE NOT Comparison
+    
+    -- Checks the offsets
+    LET OffsetsTmp <= dict()
 
+    LET CheckOffsetsHelper(X, Y) = SELECT 
+        atoi(string=format(format="0x%x", args=substr(str=X, start=_value, end=AddressLength+_value)))
+          - atoi(string=format(format="0x%x", args=substr(str=Y, start=_value, end=AddressLength+_value))) AS Difference
+      FROM range(end=len(list=X), step=AddressLength)
+      WHERE if(condition=Difference!=0,
+        then=set(
+          item=OffsetsTmp, 
+          field=Difference, 
+          value=if(
+            condition=OffsetsTmp[format(format="%d", args=Difference)], 
+            then=1+OffsetsTmp[format(format="%d", args=Difference)], 
+            else=1
+          )
+        )
+      )
+    
+    LET CheckOffsets(X, Y) = CheckOffsetsHelper(X=X, Y=Y)
+ 
+    -- If enabled, checks the offsets
+    LET FilteredContentWithMetadata(Pid, Name) = SELECT Pid,
+               PidFilename,
+               Path,
+               CheckOffsets(X=MemoryData, Y=DiskData) AS OffsetComparison,
+               Comparison,
+               MemorySHA256,
+               DiskSHA256,
+               MemAddress,
+               DiskAddress,
+               SegmentSize
+        FROM FilterContent(Pid=Pid, Name=Name)
+    
     -- Dict stored as query, so it only gets executed once
     LET Tmp <= dict(a=0)
-
+    
     LET Cmp(X, Y) = SELECT X[_value] = Y[_value]  AND X[1] = Y[1] AS Eq
-        FROM range(end=len(list=X), step=2)
-        WHERE set(item=Tmp,
+      FROM range(end=len(list=X), step=2)
+      WHERE set(item=Tmp,
                 field="a",
                 value=if(condition=Eq  AND Tmp.a < 2, then=0, else=Tmp.a + 1))
-        AND Tmp.a > 2
-        LIMIT 1
-
-    LET CheckOneByteChanges(X, Y) = set(item=Tmp, field="a", value=0)
-        AND Cmp(X=X, Y=Y)
-
+       AND Tmp.a > 2
+      LIMIT 1
+    
+    LET CheckOneByteChanges(X, Y) = (X = Y
+         AND log(message="Comparing %v quickly", dedup=-1, args=len(list=X))) OR (
+          set(item=Tmp, field="a", value=0)
+         && Cmp(X=X, Y=Y))
+    
     -- compare the executable from memory and hard disk
     -- only print the ones where they do not match
-    LET Compare =
-        if(condition=IgnoreOneByteOffsets, then={
-            SELECT Pid,
-                Path,
-                NOT CheckOneByteChanges(X=MemoryData, Y=DiskData)
-                    AS OneByteOffset,
-                Comparison,
-                MemorySHA256,
-                DiskSHA256,
-                MemAddress,
-                DiskAddress,
-                TextSegmentData.Size AS Size
-            FROM FilterContent
-            WHERE NOT OneByteOffset
-        }, else={
-            SELECT Pid, 
-                Path,
-                Comparison,
-                MemorySHA256,
-                DiskSHA256,
-                MemAddress,
-                DiskAddress,
-                TextSegmentData.Size AS Size
-            FROM FilterContent
-        })
-
+    LET Compare(Pid, Name) = if(
+        condition=log(message="Comparing process %v", args=Pid)
+         AND IgnoreOneByteOffsets,
+        then={
+        SELECT Pid,
+               PidFilename,
+               Path,
+               NOT CheckOneByteChanges(X=MemoryData, Y=DiskData) AS OneByteOffset,
+               Comparison,
+               OffsetComparison,
+               MemorySHA256,
+               DiskSHA256,
+               MemAddress,
+               DiskAddress,
+               SegmentSize
+        FROM FilteredContentWithMetadata(Pid=Pid, Name=Name)
+        WHERE NOT OneByteOffset
+      },
+        else={
+        SELECT Pid,
+               PidFilename,
+               Path,
+               Comparison,
+               OffsetComparison,
+               MemorySHA256,
+               DiskSHA256,
+               MemAddress,
+               DiskAddress,
+               SegmentSize
+        FROM FilteredContentWithMetadata(Pid=Pid, Name=Name)
+      })
+    
     -- compare with uploading the suspicious executables
-    LET CompareAndUpload =
-        SELECT Pid, Path, MemAddress, DiskAddress, Size,
-            upload(
-                file=format(format="/%d", args=Pid),
-                --offset=Address,
-                --length=TextSegmentData.Size,
-                name=Path+"."+format(format="%d", args=Pid)+".mem",
-                accessor="process"
-            ) AS UploadMem,
-            upload(
-                file=Path,
-                --offset=TextSegmentData.FileOffset,
-                --length=TextSegmentData.Size,
-                name=Path+"."+format(format="%d", args=Pid)+".disk",
-                accessor="file"
-            ) AS UploadDisk
-        FROM Compare
-
+    LET CompareAndUpload(Pid, Name) = SELECT
+        Pid,
+        Path,
+        Hex(X=MemAddress) AS MemAddress,
+        Hex(X=DiskAddress) AS DiskAddress,
+        Hex(X=SegmentSize) AS SegmentSize,
+        upload(
+          file=pathspec(DelegateAccessor="process",
+                        DelegatePath=PidFilename,
+                        Path=[dict(Offset=MemAddress, Length=SegmentSize), ]),
+          name=pathspec(parse=format(format="%s.%d.mem", args=[Path, Pid]),
+                        path_type="windows"),
+          accessor="sparse") AS UploadMem,
+        upload(
+          file=pathspec(DelegateAccessor="file",
+                        DelegatePath=Path,
+                        Path=[dict(Offset=DiskAddress, Length=SegmentSize), ]),
+          name=pathspec(parse=format(format="%s.%d.disk", args=[Path, Pid]),
+                        path_type="windows"),
+          accessor="sparse") AS UploadDisk
+      FROM Compare(Pid=Pid, Name=Name)
+    
     -- for every process, evaluate the memory-harddisk-comparison
-    SELECT * FROM foreach(
-      row=GetPids,
-      query=if(condition=UploadFindings, then=CompareAndUpload, else=Compare)
-    )
+    SELECT *
+    FROM foreach(row=GetPids,
+                 workers=20,
+                 query={
+        SELECT *
+        FROM if(condition=UploadFindings,
+                then={
+        SELECT *
+        FROM CompareAndUpload(Pid=Pid, Name=Name)
+      },
+                else={
+        SELECT *
+        FROM Compare(Pid=Pid, Name=Name)
+      })
+      })

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -32,7 +32,11 @@ parameters:
                a binary, replace with `.*`. The default parameter checks the original binary itself (.exe)
                as well as kernelbase.dll, ntdll.dll, user32.dll, kernel32.dll, shell32.dll, msvcrt.dll,
                advapi32.dll, and comdlg32.dll (i.e. commonly injected libraries).
-  default: ".*\\.exe|(KERNELBASE|ntdll|user32|kenrel32|shell32|msvcrt|advapi32|comdlg32)\\.dll"
+  default: "\\.exe$|(KERNELBASE|ntdll|user32|kenrel32|shell32|msvcrt|advapi32|comdlg32)\\.dll$"
+- name: Workers
+  type: int
+  default: "5"
+  description: "Number of parallel workers to use"
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -62,7 +66,7 @@ sources:
                          if(condition=IsWow64, then=4, else=8) AS IntSize
       FROM pslist()
       WHERE Name =~ ProcessNameFilter
-    
+
     -- get all memory pages for a certain pid
     LET InfoFromVad(Pid) = SELECT Address,
                                   Size,
@@ -71,16 +75,16 @@ sources:
       WHERE MappingName
       AND Protection =~ "xr-"
       AND MappingName =~ ModuleRegEx
-      LIMIT 1
-    
+
     LET GetTextSegment(Path) = filter(condition="x=>x.Name = '.text'",
                                       list=parse_pe(file=Path).Sections)[0]
-    
+
     -- parse the executable (PE) from memory (specifically, the text segment)
-    LET GetMetadata(Pid) = SELECT Path,
-                                  str(str=Pid) AS PidFilename,
-                                  Address,
-                                  GetTextSegment(Path=Path) AS TextSegmentData
+    LET GetMetadata(Pid) = SELECT
+         Path,
+         str(str=Pid) AS PidFilename,
+         Address,
+         GetTextSegment(Path=Path) AS TextSegmentData
       FROM InfoFromVad(Pid=Pid)
       WHERE Address != 0
       AND TextSegmentData.FileOffset
@@ -92,12 +96,29 @@ sources:
                             struct="int64",
                             accessor="data",
                             filename=X)
-    
+
+    -- ASLR may be shifted due to alignment.
+    -- This is OK so the following values are allowed.
+    LET CalculateAllowedASLR(ASLR) = SELECT *
+      FROM foreach(row={
+        SELECT format(format="00" * 7 + "%08x" + "00" * 8, args=ASLR) AS Data
+        FROM scope()
+      }, query={
+        SELECT int(int="0x" + Data[_value:(_value + 16)]) AS Allowed
+        FROM range(start=0, end=22, step=2)
+    })
+
     -- read the executable from memory and hard disk
     LET GetContent(Pid, Name) = SELECT
-        *, Name,
+        *,
+        Name,
+        Path,
         Address AS MemAddress,
-        Hex(X=Address - TextSegmentData.VMA) AS ASLR, --calculate ASLR offset to later filter it out
+
+        --calculate ASLR offset to later filter it out
+        Address - TextSegmentData.VMA AS ASLR,
+
+        CalculateAllowedASLR(ASLR=Address - TextSegmentData.VMA).Allowed AS AllowedASLR,
         read_file(accessor="process",
                   offset=Address,
                   filename=PidFilename,
@@ -111,13 +132,15 @@ sources:
       FROM GetMetadata(Pid=Pid)
       WHERE MemoryData
       AND log(dedup=-1,
-              message="Inspecting Pid %v (%v): %#x-%#x vs %#x-%#x",
+              message="Inspecting Pid %v (%v): %#x-%#x vs %#x-%#x in %v",
               args=[Pid, Name, Address, Address + SegmentSize,
-                DiskAddress, DiskAddress + SegmentSize])
+                DiskAddress, DiskAddress + SegmentSize, Path])
 
-    -- Filter out not needed comparisons early
-    LET FilterContent(Pid, Name) = SELECT *, MemoryData = DiskData AS Comparison
+    LET FilterContent(Pid, Name) = SELECT *
+      MemoryData = DiskData AS Comparison
       FROM GetContent(Pid=Pid, Name=Name)
+
+      -- Filter out not needed comparisons early
       WHERE NOT Comparison
 
     -- parameter for start PAGESIZE; compare 1 MB pages first
@@ -140,7 +163,8 @@ sources:
         Offset,
         Hex(X=XInt) AS X,
         Hex(X=YInt) AS Y,
-        Hex(X=Int64(X=XInt) - Int64(X=YInt)) AS Difference
+        Int64(X=XInt) AS ValueX,
+        Int64(X=YInt) AS ValueY
       FROM foreach(row={
         -- 1 MB pages
         SELECT *
@@ -163,51 +187,49 @@ sources:
 
     -- check if offsets between X and Y (i.e. RAM and disk) are
     -- always the same offset. Then it is ASLR or BaseOfData.
-    LET CompareUniqueRegions(X, Y, IntSize, ASLR) = SELECT *
+    LET CompareUniqueRegions(X, Y, IntSize, ASLR) = SELECT *,
+        ValueX - ValueY AS Difference
       FROM CompareRegions(X=X, Y=Y, IntSize=IntSize)
-      WHERE Difference != ASLR --filter out ASLR
+      WHERE ValueX AND NOT Difference IN AllowedASLR
       GROUP BY Difference
 
     -- compare the executable from memory and hard disk
     -- only print the ones where they do not match
-    LET Compare(Pid, Name, IntSize) = 
+    LET Compare(Pid, Name, IntSize) =
       SELECT Pid,
              Name,
+             Path,
              ASLR,
              IntSize,
              PidFilename,
-             Path,
              {
                SELECT Offset,
                       X AS MemoryValue,
                       Y AS DiskValue,
-                      Difference,
-                      ASLR
-               FROM CompareUniqueRegions(X=MemoryData, Y=DiskData, IntSize=IntSize, ASLR=ASLR)
-               -- filter out BaseOfData by shifting the binary value
-               -- to the correct position (256 = shift by 1 byte)
-               WHERE int(int=Difference) / 256 != int(int=ASLR)
-               AND int(int=Difference) / 256 / 256 != int(int=ASLR)
-               AND int(int=Difference) / 256 / 256 / 256 != int(int=ASLR)
-               AND int(int=Difference) * 256 != int(int=ASLR)
-               AND int(int=Difference) * 256 * 256 != int(int=ASLR)
-               AND int(int=Difference) * 256 * 256 * 256 != int(int=ASLR)
+                      Hex(X=Difference) AS Difference,
+                      Hex(X=ASLR) AS ASLR
+               FROM CompareUniqueRegions(
+                     X=MemoryData,
+                     Y=DiskData,
+                     IntSize=IntSize,
+                     ASLR=ASLR)
              } AS Differences,
              MemAddress,
              DiskAddress,
              SegmentSize
       FROM FilterContent(Pid=Pid, Name=Name)
-      WHERE log(message="Comparing process %v - %v", args=[Pid, Name])
-            AND Differences -- filter processes with no differences other than ASLR offsets
-            --FIXME: AND (len(list=Differences) != 1 AND IntSize=4) -- filter out BaseOfData and ignore one constant offset
+      WHERE Differences AND log(dedup=-1,
+          message="Comparing process %v - %v", args=[Pid, Name])
 
     -- compare with uploading the suspicious executables
     LET CompareAndUpload(Pid, Name, IntSize) = SELECT
         Pid,
+        Name,
         Path,
-        Hex(X=MemAddress) AS MemAddress,
-        Hex(X=DiskAddress) AS DiskAddress,
-        Hex(X=SegmentSize) AS SegmentSize,
+        ASLR,
+        MemAddress,
+        DiskAddress,
+        SegmentSize,
         upload(
           file=pathspec(DelegateAccessor="process",
                         DelegatePath=PidFilename,
@@ -225,9 +247,12 @@ sources:
       FROM Compare(Pid=Pid, Name=Name, IntSize=IntSize)
 
     -- for every process, evaluate the memory-harddisk-comparison
-    SELECT *
+    SELECT *,
+      Hex(X=MemAddress) AS MemAddress,
+      Hex(X=DiskAddress) AS DiskAddress,
+      Hex(X=SegmentSize) AS SegmentSize
     FROM foreach(row=GetPids,
-                workers=20,
+                 workers=Workers,
       query={
         SELECT *
         FROM if(condition=UploadFindings,

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -22,11 +22,11 @@ parameters:
   type: bool
 - name: ProcessNameFilter
   type: regex
-  default: .*
-- name: AddressLength
-  type: int
-  default: 8
-  description: Length of the address/architecture (e.g. 8 for x64, 4 for x86)
+  default: .
+- name: ModuleRegEx
+  type: regex
+  description: Filter for modules to check.
+  default: "(KERNELBASE|ntdll).dll|.exe"
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -39,11 +39,11 @@ export: |
       len(list=SymlinkTarget) AS Len
     FROM winobj()
     WHERE Name =~ "^\\\\GLOBAL\\?\\?\\\\.:"
-  
+
   LET _DriveReplace(Path) = SELECT Drive + Path[Len:] AS ResolvedPath
     FROM DriveReplaceLookup
     WHERE upcase(string=Path[:Len]) = Target
-  
+
   LET DriveReplace(Path) = _DriveReplace(Path=Path)[0].ResolvedPath ||
       Path
 
@@ -52,7 +52,8 @@ sources:
     -- get all processes
     LET GetPids = SELECT Pid,
                          Name,
-                         Username
+                         Username,
+                         if(condition=IsWow64, then=4, else=8) AS IntSize
       FROM pslist()
       WHERE Name =~ ProcessNameFilter
     
@@ -63,148 +64,132 @@ sources:
       FROM vad(pid=Pid)
       WHERE MappingName
        AND Protection =~ "xr-"
-            AND MappingName =~ "(exe)$"
+            AND MappingName =~ ModuleRegEx
       LIMIT 1
     
     LET GetTextSegment(Path) = filter(condition="x=>x.Name = '.text'",
                                       list=parse_pe(file=Path).Sections)[0]
     
     -- parse the executable (PE) from memory (specifically, the text segment)
-    LET GetMetadata(Pid, Name) = SELECT
-        Path,
-        str(str=Pid) AS PidFilename,
-        Address,
-        GetTextSegment(Path=Path) AS TextSegmentData
+    LET GetMetadata(Pid) = SELECT Path,
+                                  str(str=Pid) AS PidFilename,
+                                  Address,
+                                  GetTextSegment(Path=Path) AS TextSegmentData
       FROM InfoFromVad(Pid=Pid)
       WHERE Address != 0
-       AND TextSegmentData.FileOffset
+      AND TextSegmentData.FileOffset
     
     LET Hex(X) = format(format="%#x", args=X)
+
+    LET Int64(X) = parse_binary(profile="",
+                            struct="int64",
+                            accessor="data",
+                            filename=X)
     
     -- read the executable from memory and hard disk
-    LET GetContent(Pid, Name) = SELECT *, Address AS MemAddress,
-                                       read_file(
-                                         accessor="process",
-                                         offset=Address,
-                                         filename=PidFilename,
-                                         length=TextSegmentData.Size) AS MemoryData,
-                                       hash(
-                                         path=PidFilename,
-                                         accessor="process",
-                                         hashselect="SHA256").SHA256 AS MemorySHA256,
-                                       TextSegmentData.FileOffset AS DiskAddress,
-                                       TextSegmentData.Size AS SegmentSize,
-                                       read_file(
-                                         accessor="file",
-                                         offset=TextSegmentData.FileOffset,
-                                         filename=Path,
-                                         length=TextSegmentData.Size) AS DiskData,
-                                       hash(
-                                         path=Path,
-                                         accessor="file",
-                                         hashselect="SHA256").SHA256 AS DiskSHA256
-      FROM GetMetadata(
-        Name=Name,
-        Pid=Pid)
+    LET GetContent(Pid, Name) = SELECT
+        *, Name,
+        Address AS MemAddress,
+        Hex(X=Address - TextSegmentData.VMA) AS ASLR, 
+        read_file(accessor="process",
+                  offset=Address,
+                  filename=PidFilename,
+                  length=TextSegmentData.Size) AS MemoryData,
+        TextSegmentData.FileOffset AS DiskAddress,
+        TextSegmentData.Size AS SegmentSize,
+        read_file(accessor="file",
+                  offset=TextSegmentData.FileOffset,
+                  filename=Path,
+                  length=TextSegmentData.Size) AS DiskData
+      FROM GetMetadata(Pid=Pid)
       WHERE MemoryData
-       AND log(
-             dedup=-1,
-             message="Inspecting Pid %v (%v): %#x-%#x vs %#x-%#x",
-             args=[Pid, Name, Address, Address + SegmentSize,
-               DiskAddress, DiskAddress + SegmentSize])
-    
+      AND log(dedup=-1,
+              message="Inspecting Pid %v (%v): %#x-%#x vs %#x-%#x",
+              args=[Pid, Name, Address, Address + SegmentSize,
+                DiskAddress, DiskAddress + SegmentSize])
+
     -- Filter out not needed comparisons early
     LET FilterContent(Pid, Name) = SELECT *, MemoryData = DiskData AS Comparison
       FROM GetContent(Pid=Pid, Name=Name)
       WHERE NOT Comparison
-    
-    -- Checks the offsets
-    LET OffsetsTmp <= dict()
 
-    -- TODO: integrate the OneByteOffset comparison into here
-    LET CheckOffsetsHelper(X, Y) = SELECT 
-        atoi(string=format(format="0x%x", args=substr(str=X, start=_value, end=AddressLength+_value)))
-          - atoi(string=format(format="0x%x", args=substr(str=Y, start=_value, end=AddressLength+_value))) AS Difference
-      FROM range(end=len(list=X), step=AddressLength)
-      WHERE if(condition=Difference!=0,
-        then=set(
-          item=OffsetsTmp, 
-          field=Difference, 
-          value=if(
-            condition=OffsetsTmp[format(format="%d", args=Difference)], 
-            then=1+OffsetsTmp[format(format="%d", args=Difference)], 
-            else=1
-          )
-        )
-      )
-    
-    LET CheckOffsets(X, Y) = CheckOffsetsHelper(X=X, Y=Y)
- 
-    -- If enabled, checks the offsets
-    LET FilteredContentWithMetadata(Pid, Name) = SELECT Pid,
-               PidFilename,
-               Path,
-               CheckOffsets(X=MemoryData, Y=DiskData) AS OffsetComparison,
-               Comparison,
-               MemorySHA256,
-               DiskSHA256,
-               MemAddress,
-               DiskAddress,
-               SegmentSize
-        FROM FilterContent(Pid=Pid, Name=Name)
-    
-    -- Dict stored as query, so it only gets executed once
-    LET Tmp <= dict(a=0)
-    
-    LET Cmp(X, Y) = SELECT X[_value] = Y[_value]  AND X[1] = Y[1] AS Eq
-      FROM range(end=len(list=X), step=2)
-      WHERE set(item=Tmp,
-                field="a",
-                value=if(condition=Eq AND Tmp.a < 2, then=0, else=Tmp.a + 1))
-       AND Tmp.a > 2
-      LIMIT 1
-    
-    LET CheckOneByteChanges(X, Y) = (X = Y
-         AND log(message="Comparing %v quickly", dedup=-1, args=len(list=X))) OR (
-          set(item=Tmp, field="a", value=0)
-         && Cmp(X=X, Y=Y))
-    
+    LET PAGESIZE <= 1024 * 1024
+
+    LET _CompareRegions(Base, X, Y, PAGESIZE) = SELECT
+        _value + Base AS Offset,
+        X[_value:(_value + PAGESIZE)] AS XInt,
+        Y[_value:(_value + PAGESIZE)] AS YInt
+      FROM range(end=len(list=X), step=PAGESIZE)
+      WHERE XInt != YInt
+
+    LET CompareRegions(X, Y, IntSize) = SELECT
+        Offset,
+        Hex(X=XInt) AS X,
+        Hex(X=YInt) AS Y,
+        Hex(X=Int64(X=XInt) - Int64(X=YInt)) AS Difference
+      FROM foreach(row={
+        SELECT *
+        FROM _CompareRegions(Base=0, X=X, Y=Y, PAGESIZE=PAGESIZE)
+      },
+                  query={
+        SELECT *
+        FROM foreach(row={
+        SELECT *
+        FROM _CompareRegions(Base=Offset, X=XInt, Y=YInt, PAGESIZE=4096)
+      },
+                    query={
+        SELECT *
+        FROM _CompareRegions(Base=Offset, X=XInt, Y=YInt, PAGESIZE=IntSize)
+      })
+      })
+      LIMIT 500
+
+    LET CompareUniqueRegions(X, Y, IntSize, ASLR) = SELECT *
+      FROM CompareRegions(X=X, Y=Y, IntSize=IntSize)
+      WHERE Difference != ASLR
+      GROUP BY Difference
+
     -- compare the executable from memory and hard disk
     -- only print the ones where they do not match
-    LET Compare(Pid, Name) = if(
+    LET Compare(Pid, Name, IntSize) = if(
         condition=log(message="Comparing process %v", args=Pid)
-         AND IgnoreOneByteOffsets,
+        AND IgnoreOneByteOffsets,
         then={
         SELECT Pid,
-               PidFilename,
-               Path,
-               NOT CheckOneByteChanges(X=MemoryData, Y=DiskData) AS OneByteOffset,
-               Comparison,
-               OffsetComparison,
-               MemorySHA256,
-               DiskSHA256,
-               MemAddress,
-               DiskAddress,
-               SegmentSize
-        FROM FilteredContentWithMetadata(Pid=Pid, Name=Name)
+              Name,
+              ASLR,
+              IntSize,
+              PidFilename,
+              Path,
+              {
+        SELECT Offset,
+              X AS MemoryValue,
+              Y AS DiskValue,
+              Difference,
+              Hex(X=ASLR) AS ASLR
+        FROM CompareUniqueRegions(X=MemoryData, Y=DiskData, IntSize=IntSize, ASLR=ASLR)
+        } AS Differences,
+              MemAddress,
+              DiskAddress,
+              SegmentSize
+        FROM FilterContent(Pid=Pid, Name=Name)
         WHERE NOT OneByteOffset
       },
         else={
         SELECT Pid,
-               PidFilename,
-               Path,
-               Comparison,
-               OffsetComparison,
-               MemorySHA256,
-               DiskSHA256,
-               MemAddress,
-               DiskAddress,
-               SegmentSize
-        FROM FilteredContentWithMetadata(Pid=Pid, Name=Name)
+              Name,
+              ASLR,
+              IntSize,
+              PidFilename,
+              Path,
+              MemAddress,
+              DiskAddress,
+              SegmentSize
+        FROM FilterContent(Pid=Pid, Name=Name)
       })
-    
+
     -- compare with uploading the suspicious executables
-    LET CompareAndUpload(Pid, Name) = SELECT
+    LET CompareAndUpload(Pid, Name, IntSize) = SELECT
         Pid,
         Path,
         Hex(X=MemAddress) AS MemAddress,
@@ -224,21 +209,21 @@ sources:
           name=pathspec(parse=format(format="%s.%d.disk", args=[Path, Pid]),
                         path_type="windows"),
           accessor="sparse") AS UploadDisk
-      FROM Compare(Pid=Pid, Name=Name)
-    
+      FROM Compare(Pid=Pid, Name=Name, IntSize=IntSize)
+
     -- for every process, evaluate the memory-harddisk-comparison
     SELECT *
     FROM foreach(row=GetPids,
-                 workers=20,
-                 query={
+                workers=20,
+                query={
         SELECT *
         FROM if(condition=UploadFindings,
                 then={
         SELECT *
-        FROM CompareAndUpload(Pid=Pid, Name=Name)
+        FROM CompareAndUpload(Pid=Pid, Name=Name, IntSize=IntSize)
       },
                 else={
         SELECT *
-        FROM Compare(Pid=Pid, Name=Name)
+        FROM Compare(Pid=Pid, Name=Name, IntSize=IntSize)
       })
       })

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -82,31 +82,19 @@ sources:
       FROM GetContent
       WHERE NOT Comparison
 
-    -- PowerShell compare script as stored query, so it only gets created once
-    LET PowerShellScript <= tempfile(extension=".ps1", data='''
-        param([string]$file1, [string]$file2)
-        if($file1.Length -eq 0 -or $file2.Length -eq 0){
-            Exit $false
-        }
-        $str1 = Get-Content -Path $file1
-        $str2 = Get-Content -Path $file2
-        if($str1.Length -ne $str2.Length){
-            Exit $false
-        }
-        $tmp = 0
-        for($i = 0; $i -le $str1.Length; $i+=2){
-            if($str1[$i] -eq $str2[$i] -and $str1[$i+1] -eq $str2[$i+1]){
-                $tmp=0
-            }else{
-                $tmp++
-                if($tmp -ge 2){
-                    Exit $false
-                }
-            }
-        }
-        Exit $true''')
-    LET CheckOneByteChanges(file1, file2) =
-                SELECT * FROM execve(argv=["Powershell", "-ExecutionPolicy", "unrestricted", "-c", PowerShellScript, file1, file2])
+    -- Dict stored as query, so it only gets executed once
+    LET Tmp <= dict(a=0)
+
+    LET Cmp(X, Y) = SELECT X[_value] = Y[_value]  AND X[1] = Y[1] AS Eq
+        FROM range(end=len(list=X), step=2)
+        WHERE set(item=Tmp,
+                field="a",
+                value=if(condition=Eq  AND Tmp.a < 2, then=0, else=Tmp.a + 1))
+        AND Tmp.a > 2
+        LIMIT 1
+
+    LET CheckOneByteChanges(X, Y) = set(item=Tmp, field="a", value=0)
+        AND Cmp(X=X, Y=Y)
 
     -- compare the executable from memory and hard disk
     -- only print the ones where they do not match
@@ -114,9 +102,8 @@ sources:
         if(condition=IgnoreOneByteOffsets, then={
             SELECT Pid,
                 Path,
-                CheckOneByteChanges(file1=tempfile(extension=".mem", data=MemoryData),
-                    file2=tempfile(extension=".disk", data=DiskData))[0].ReturnCode != 0
-                    AS OneByteOffset, --$false = 0
+                NOT CheckOneByteChanges(X=MemoryData, Y=DiskData)
+                    AS OneByteOffset,
                 Comparison,
                 MemorySHA256,
                 DiskSHA256,

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -1,0 +1,163 @@
+name: Windows.Memory.Mem2Disk
+author: Lautaro Lecumberry, Dr. Michael Denzel
+description: |
+    This artifact compares executables in memory (RAM) with those
+    on hard disk. This way, RAM injections are detected. This rarely
+    happens legitimately and is mostly used by malware.
+    This check is executed without dumping the memory and works live
+    on the target system(s).
+
+parameters:
+- name: IgnoreOneByteOffsets
+  description: Relative Virtual Adresses (RVA) cause an offset in the code in memory of a process.
+               This is the case when the field BaseOfData is set to 0x8000. It creates false
+               positives and is fairly safe to ignore (1-byte injections are really hard).
+  default: True
+  type: bool
+- name: UploadFindings
+  description: Upload all executables where code in memory does not match code on disk. This
+               can potentially generate a lot of traffic. Dry-run before enabling this option.
+  default: False
+  type: bool
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+sources:
+- query: |
+    -- get all processes
+    LET GetPids =
+      SELECT Pid, Username
+      FROM pslist()
+
+    -- get all memory pages for a certain pid
+    LET InfoFromVad = 
+      SELECT 
+        atoi(string="0x"+split(string=AddressRange, sep="-")[0]) as Address,
+        filter(list=ProcessChain, regex=Pid)[0].Exe as Path
+      FROM Artifact.Windows.System.VAD(PidRegex=str(str=Pid))
+      WHERE MappingName
+        AND Protection =~ "xr-"
+        AND MappingName =~ "(exe)$"
+
+    -- parse the executable (PE) from memory (specifically, the text segment)
+    LET GetMetadata =
+      SELECT Path,
+        Address,
+        parse_pe(file=Path).Sections[0] AS TextSegmentData
+      FROM InfoFromVad
+      WHERE Address != 0
+
+    -- read the executable from memory and hard disk
+    LET GetContent =
+      SELECT *,
+        format(format="%#x", args=Address) AS MemAddress,
+        format(format="%x",
+          args=read_file(accessor="process",
+            offset=Address,
+            filename=format(format="/%d", args=Pid),
+            length=TextSegmentData.Size)
+          ) AS MemoryData,
+        hash(path=format(format="/%d", args=Pid),
+            accessor="process",
+            hashselect="SHA256"
+          ).SHA256 AS MemorySHA256,
+        format(format="%#x", args=TextSegmentData.FileOffset) AS DiskAddress,
+        format(format="%x",
+          args=read_file(accessor="file",
+            offset=TextSegmentData.FileOffset,
+            filename=Path,
+            length=TextSegmentData.Size)
+          ) AS DiskData,
+        hash(path=Path,
+          accessor="file",
+          hashselect="SHA256"
+        ).SHA256 AS DiskSHA256
+      FROM GetMetadata
+      WHERE len(list=MemoryData) != 0
+        AND len(list=DiskData) != 0
+
+    -- Filter out not needed comparisons early
+    LET FilterContent =
+      SELECT *, MemoryData = DiskData AS Comparison
+      FROM GetContent
+      WHERE NOT Comparison
+
+    -- PowerShell compare script as stored query, so it only gets created once
+    LET PowerShellScript <= tempfile(extension=".ps1", data='''
+        param([string]$file1, [string]$file2)
+        if($file1.Length -eq 0 -or $file2.Length -eq 0){
+            Exit $false
+        }
+        $str1 = Get-Content -Path $file1
+        $str2 = Get-Content -Path $file2
+        if($str1.Length -ne $str2.Length){
+            Exit $false
+        }
+        $tmp = 0
+        for($i = 0; $i -le $str1.Length; $i+=2){
+            if($str1[$i] -eq $str2[$i] -and $str1[$i+1] -eq $str2[$i+1]){
+                $tmp=0
+            }else{
+                $tmp++
+                if($tmp -ge 2){
+                    Exit $false
+                }
+            }
+        }
+        Exit $true''')
+    LET CheckOneByteChanges(file1, file2) =
+                SELECT * FROM execve(argv=["Powershell", "-ExecutionPolicy", "unrestricted", "-c", PowerShellScript, file1, file2])
+
+    -- compare the executable from memory and hard disk
+    -- only print the ones where they do not match
+    LET Compare =
+        if(condition=IgnoreOneByteOffsets, then={
+            SELECT Pid,
+                Path,
+                CheckOneByteChanges(file1=tempfile(extension=".mem", data=MemoryData),
+                    file2=tempfile(extension=".disk", data=DiskData))[0].ReturnCode != 0
+                    AS OneByteOffset, --$false = 0
+                Comparison,
+                MemorySHA256,
+                DiskSHA256,
+                MemAddress,
+                DiskAddress,
+                TextSegmentData.Size AS Size
+            FROM FilterContent
+            WHERE NOT OneByteOffset
+        }, else={
+            SELECT Pid, 
+                Path,
+                Comparison,
+                MemorySHA256,
+                DiskSHA256,
+                MemAddress,
+                DiskAddress,
+                TextSegmentData.Size AS Size
+            FROM FilterContent
+        })
+
+    -- compare with uploading the suspicious executables
+    LET CompareAndUpload =
+        SELECT Pid, Path, MemAddress, DiskAddress, Size,
+            upload(
+                file=format(format="/%d", args=Pid),
+                --offset=Address,
+                --length=TextSegmentData.Size,
+                name=Path+"."+format(format="%d", args=Pid)+".mem",
+                accessor="process"
+            ) AS UploadMem,
+            upload(
+                file=Path,
+                --offset=TextSegmentData.FileOffset,
+                --length=TextSegmentData.Size,
+                name=Path+"."+format(format="%d", args=Pid)+".disk",
+                accessor="file"
+            ) AS UploadDisk
+        FROM Compare
+
+    -- for every process, evaluate the memory-harddisk-comparison
+    SELECT * FROM foreach(
+      row=GetPids,
+      query=if(condition=UploadFindings, then=CompareAndUpload, else=Compare)
+    )

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -32,7 +32,7 @@ parameters:
                a binary, replace with `.*`. The default parameter checks the original binary itself (.exe)
                as well as kernelbase.dll, ntdll.dll, user32.dll, kernel32.dll, shell32.dll, msvcrt.dll,
                advapi32.dll, and comdlg32.dll (i.e. commonly injected libraries).
-  default: "\\.exe$|(KERNELBASE|ntdll|user32|kenrel32|shell32|msvcrt|advapi32|comdlg32)\\.dll$"
+  default: "\\.exe$|(KERNELBASE|ntdll|user32|kernel32|shell32|msvcrt|advapi32|comdlg32)\\.dll$"
 - name: Workers
   type: int
   default: "5"

--- a/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
+++ b/content/exchange/artifacts/Windows.Memory.Mem2Disk.yaml
@@ -16,6 +16,10 @@ description: |
                     32-bit process. This is the case when the field BaseOfData is set.
                     Like ASLR it is a constant offset that is added to addresses.
 
+    Test this artifact using `AMSIBypassPatch.ps1`
+
+references:
+  - https://github.com/okankurtuluss/AMSIBypassPatch/blob/090b54a518fecf1ccf8f54f8691805ef0f9a30f1/AMSIBypassPatch.ps1
 
 parameters:
 - name: UploadFindings
@@ -32,7 +36,7 @@ parameters:
                a binary, replace with `.*`. The default parameter checks the original binary itself (.exe)
                as well as kernelbase.dll, ntdll.dll, user32.dll, kernel32.dll, shell32.dll, msvcrt.dll,
                advapi32.dll, and comdlg32.dll (i.e. commonly injected libraries).
-  default: "\\.exe$|(KERNELBASE|ntdll|user32|kernel32|shell32|msvcrt|advapi32|comdlg32)\\.dll$"
+  default: "\\.exe$|(KERNELBASE|ntdll|amsi|user32|kenrel32|shell32|msvcrt|advapi32|comdlg32)\\.dll$"
 - name: Workers
   type: int
   default: "5"
@@ -114,7 +118,7 @@ sources:
         Name,
         Path,
         Address AS MemAddress,
-
+        TextSegmentData.RVA AS BaseRVA,
         --calculate ASLR offset to later filter it out
         Address - TextSegmentData.VMA AS ASLR,
 
@@ -193,6 +197,9 @@ sources:
       WHERE ValueX AND NOT Difference IN AllowedASLR
       GROUP BY Difference
 
+    LET DescribeAddress(rva, module) = version(function="describe_address") != NULL &&
+       describe_address(rva=rva, module=module).func
+
     -- compare the executable from memory and hard disk
     -- only print the ones where they do not match
     LET Compare(Pid, Name, IntSize) =
@@ -200,10 +207,10 @@ sources:
              Name,
              Path,
              ASLR,
-             IntSize,
-             PidFilename,
              {
-               SELECT Offset,
+               SELECT Offset + BaseRVA AS RVA,
+                      Offset AS TextOffset,
+                      DescribeAddress(rva= Offset + BaseRVA, module=Path) AS Func,
                       X AS MemoryValue,
                       Y AS DiskValue,
                       Hex(X=Difference) AS Difference,
@@ -243,7 +250,8 @@ sources:
                         Path=[dict(Offset=DiskAddress, Length=SegmentSize), ]),
           name=pathspec(parse=format(format="%s.%d.disk", args=[Path, Pid]),
                         path_type="windows"),
-          accessor="sparse") AS UploadDisk
+          accessor="sparse") AS UploadDisk,
+        Differences
       FROM Compare(Pid=Pid, Name=Name, IntSize=IntSize)
 
     -- for every process, evaluate the memory-harddisk-comparison


### PR DESCRIPTION
This artifact compares executables in memory (RAM) with those on hard disk. This way, RAM injections are detected. This rarely happens legitimately and is mostly used by malware. This check is executed without dumping the memory and works live on the target system(s).