### PR TITLE
Exclude container events in Linux detection honeyfiles YAML

### DIFF
--- a/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
+++ b/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
@@ -136,6 +136,7 @@ sources:
         FROM watch_ebpf(events=["security_file_open"])
         WHERE System.EventName = "security_file_open"
          AND System.ProcessID != CurrentPid
+              AND System.HostProcessID = System.ProcessID
       
       LET AuditEvents = SELECT
           *, timestamp(string=System.Timestamp) AS Timestamp,


### PR DESCRIPTION
Excludes containers by checking the process id equals the host process id, this reduces CPU usage on systems with many containers.