### PR TITLE
Update Windows.EventLog.Hayabusa

### DIFF
--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -12,10 +12,10 @@ description: |
 author: Eric Capuano - @eric_capuano, Whitney Champion - @shortxstack, Zach Mathis - @yamatosecurity, Fukusuke Takahashi - @fukusuket, Julian Hill - @julianghill
 
 tools:
- - name: Hayabusa-3.7.0
-   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.7.0/hayabusa-3.7.0-win-x64-live-response.zip
-   expected_hash: d9530d7ddcc1ba2c7a0512b49140c8e4f5d918925248ce853a62926a8d718564
-   version: 3.7.0
+ - name: Hayabusa-3.8.0
+   url: https://github.com/Yamato-Security/hayabusa/releases/download/v3.8.0/hayabusa-3.8.0-win-x64-live-response.zip
+   expected_hash: 8ee3ba6422bfef99c2cf434a02a6497d9c56a643f76aa234ca740d1d69108981
+   version: 3.8.0
 
 precondition: SELECT OS From info() where OS = 'windows'
 
@@ -118,7 +118,7 @@ sources:
    query: |
         -- Fetch the binary
         LET Toolzip <= SELECT FullPath
-        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-3.7.0", IsExecutable=FALSE)
+        FROM Artifact.Generic.Utils.FetchBinary(ToolName="Hayabusa-3.8.0", IsExecutable=FALSE)
 
         LET TmpDir <= tempdir()
 
@@ -126,7 +126,7 @@ sources:
         LET _ <= SELECT *
         FROM unzip(filename=Toolzip.FullPath, output_directory=TmpDir)
 
-        LET HayabusaExe <= TmpDir + '\\hayabusa-3.7.0-win-x64.exe'
+        LET HayabusaExe <= TmpDir + '\\hayabusa-3.8.0-win-x64.exe'
 
         -- Optionally update the rules
         LET _ <= if(condition=UpdateRules, then={


### PR DESCRIPTION
Hi @scudette :)
Our team released [Hayabusa 3.8.0](https://github.com/Yamato-Security/hayabusa/releases/tag/v3.8.0), so I'll update Hayabusa Artifact.

Thank you so much for your time.