### PR TITLE
Enhance Chrysalis detection with new YARA rules

### DIFF
--- a/content/exchange/artifacts/Chrysalis.yaml
+++ b/content/exchange/artifacts/Chrysalis.yaml
@@ -8,8 +8,11 @@ description: |
    - Find suspicious files in public reports
    - Find public reported network urls in running processes
    - Find Warbird clipc.dll shellcode loader strings
+   - Find Shellcode and loader on disk with YARA
    
    Untoggle unwanted collections 
+   
+   Last updated: 2025-02-05
    
 
 reference:
@@ -31,6 +34,13 @@ parameters:
      description: Run targeted yara detection for Warbird clipc.dll artifacts 
      type: bool
      default: Y
+   - name: DiskYara
+     description: Run targeted yara disk detection for Chrysalis shellcode and loaders in (heavy)
+     type: bool
+     default: N
+   - name: DiskYaraGlob
+     description: Glob to use in Chrysalis disk yara.
+     default: 'C:/{Users,ProgramData}/**'
      
    - name: TargetGlobs
      description: Specify multiple globs to search for.
@@ -144,6 +154,93 @@ parameters:
                 $hex1 in (0..1167) or
                 $hex2 in (0..1167)
         }
+      
+   - name: ChrysalisYara
+     type: yara
+     default: |      
+        rule MAL_Chrysalis_DllLoader_Feb26 {
+           meta:
+              description = "Detects DLL used to load Chrysalis backdoor, seen being used in the compromise of the infrastructure hosting Notepad++ by Chinese APT group Lotus Blossom"
+              author = "X__Junior"
+              date = "2026-02-02"
+              reference = "https://www.rapid7.com/blog/post/tr-chrysalis-backdoor-dive-into-lotus-blossoms-toolkit/"
+              hash = "3bdc4c0637591533f1d4198a72a33426c01f69bd2e15ceee547866f65e26b7ad"
+              score = 80
+           strings:
+              $op1 = { 33 D2 8B C1 F7 F6 0F B6 C1 03 55 ?? 6B C0 ?? 32 02 88 04 0F 41 83 F9 ?? 72 }
+              $op2 = { 0F B6 04 31 41 33 C2 69 D0 ?? ?? ?? ?? 3B CB 72 }
+           condition:
+              uint16(0) == 0x5a4d and all of them
+        }
+        
+        rule MAL_Chrysalis_Shellcode_Loader_Feb26 {
+           meta:
+              description = "Detects shellcode used to load Chrysalis backdoor, seen being used in the compromise of the infrastructure hosting Notepad++ by Chinese APT group Lotus Blossom"
+              author = "X__Junior"
+              date = "2026-02-02"
+              reference = "https://www.rapid7.com/blog/post/tr-chrysalis-backdoor-dive-into-lotus-blossoms-toolkit/"
+              hash = "e2e3d78437cf9d48c2b2264e44bb36bc2235834fc45bbb50b5d6867f336711e3"
+              score = 80
+           strings:
+              $op1 = { 8B C7 03 D7 83 E0 ?? 47 8A 4C 05 ?? 8A 04 13 02 C1 32 C1 2A C1 88 02 8B 55 ?? 3B FE 7C ?? 8B 5D ?? 8B 45 }
+              $op2 = { 03 F8 8B 45 ?? 8B 50 ?? 85 C9 79 ?? 0F B7 C1 EB ?? 8D 41 ?? 03 C3 50 FF 75 ?? FF D2 89 07 85 C0 74 ?? 8B 4D ?? 46 }
+           condition:
+              1 of them
+        }
+        
+        rule MAL_Chrysalis_Backdoor_Feb26 {
+           meta:
+              description = "Detects Chrysalis backdoor, seen being used in the compromise of the infrastructure hosting Notepad++ by Chinese APT group Lotus Blossom"
+              author = "X__Junior"
+              date = "2026-02-02"
+              reference = "https://www.rapid7.com/blog/post/tr-chrysalis-backdoor-dive-into-lotus-blossoms-toolkit/"
+              hash = "e2e3d78437cf9d48c2b2264e44bb36bc2235834fc45bbb50b5d6867f336711e3"
+              score = 80
+           strings:
+              $opa1 = { 8B 4D ?? C1 CF ?? C1 C1 ?? 03 F9 D1 C3 8B 4D ?? C1 C1 ?? 03 F9 03 FB 8B 5D ?? 69 CF ?? ?? ?? ?? BF ?? ?? ?? ?? 2B F9 EB }
+              $opa2 = { F7 E9 [0-1] 8B C2 C1 E8 ?? 03 C2 8D 0C 40 8A C3 34 ?? [0-2] 0F B6 [1-4] 0F B6 C3 8B 5D [1-3] 0F 45 D0 }
+        
+              $opb1 = { 0F B6 84 35 ?? ?? ?? ?? 88 84 3D ?? ?? ?? ?? 88 8C 35 ?? ?? ?? ?? 0F B6 84 3D ?? ?? ?? ?? 8B 8D ?? ?? ?? ?? 03 C2 0F B6 C0 0F B6 84 05 ?? ?? ?? ?? 30 04 19 43 3B 9D ?? ?? ?? ?? 7C }
+           condition:
+              (1 of ($opa*) and $opb1)
+              or
+              all of ($opa*)
+        }
+        
+        rule MAL_CobaltStrike_Beacon_Loader_Feb26 {
+           meta:
+              description = "Detects Cobalt Strike beacon loader"
+              author = "X__Junior"
+              date = "2026-02-02"
+              reference = "https://www.rapid7.com/blog/post/tr-chrysalis-backdoor-dive-into-lotus-blossoms-toolkit/"
+              hash = "0a9b8df968df41920b6ff07785cbfebe8bda29e6b512c94a3b2a83d10014d2fd"
+              hash = "b4169a831292e245ebdffedd5820584d73b129411546e7d3eccf4663d5fc5be3"
+              score = 80
+           strings:
+              $opa1 = { 45 33 C9 41 B8 ?? ?? ?? ?? 48 8D 94 24 ?? ?? ?? ?? 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 48 8D 8C 24 ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 66 89 44 24 ?? 41 B8 ?? ?? ?? ?? 48 8D 94 24 ?? ?? ?? ?? 0F B7 4C 24 ?? FF 15 ?? ?? ?? ?? 48 8D 8C 24 ?? ?? ?? ?? FF 15 }
+              $opa2 = { 4C 8D 4C 24 ?? 41 B8 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8D 8C 24 ?? ?? ?? ?? FF 15 ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 C7 44 24 ?? ?? ?? ?? ?? C7 44 24 ?? ?? ?? ?? ?? 48 8D 8C 24 ?? ?? ?? ?? 48 89 4C 24 ?? 4C 8D 0D ?? ?? ?? ?? 45 33 C0 33 D2 48 8B C8 FF 15 }
+        
+              $opb1 = { 48 8D 89 ?? ?? ?? ?? 0F 10 00 0F 10 48 ?? 48 8D 80 ?? ?? ?? ?? 0F 11 41 ?? 0F 10 40 ?? 0F 11 49 ?? 0F 10 48 ?? 0F 11 41 ?? 0F 10 40 ?? 0F 11 49 ?? 0F 10 48 ?? 0F 11 41 ?? 0F 10 40 ?? 0F 11 49 ?? 0F 10 48 ?? 0F 11 41 ?? 0F 11 49 ?? 48 83 EA }
+              $opb2 = { 45 33 C9 48 89 84 24 ?? ?? ?? ?? 41 B8 18 00 00 00 C7 84 24 ?? ?? ?? ?? 03 00 00 00 48 8D 94 24 ?? ?? ?? ?? 48 89 BC 24 ?? ?? ?? ?? B9 B9 00 00 00 FF 15 }
+           condition:
+              uint16(0) == 0x5a4d and
+              all of ($opa*)
+              or all of ($opb*)
+        }
+        
+        rule MAL_POC_Microsoft_Warbird_Loader_Feb26 {
+           meta:
+              description = "Detects a POC to turn Microsoft Warbird into a shellcode loader"
+              author = "X__Junior"
+              date = "2026-02-03"
+              reference = "https://cirosec.de/en/news/abusing-microsoft-warbird-for-shellcode-execution/"
+              hash = "29d0467ee452752286318f350ceb28a2b04ee4c6de550ba0edc34ae0fa7cbb03"
+              score = 75
+           strings:
+              $op = { fe af fe ca ef be ad de }
+           condition:
+              uint16(0) == 0x5a4d and $op
+        }  
         
 sources:
   - query: |
@@ -204,6 +301,18 @@ sources:
                     MappingNameRegex='''clipc\.dll$''',
                     ProtectionRegex='xr-',
                     SuspiciousContent=WarbirdYara)
+            })
+            
+  - name: Disk YARA
+    query: |
+        SELECT * FROM if(
+            condition=DiskYara,
+            then={
+                SELECT *
+                  FROM Artifact.Windows.Detection.Yara.Glob(
+                        PathGlob=DiskYaraGlob,
+                        YaraRule=ChrysalisYara
+                    )
             })
 
 column_types:


### PR DESCRIPTION
Added YARA rules for detecting Chrysalis backdoor and related shellcode loaders. Updated configuration to include new detection capabilities.