### PR TITLE
Update velociraptor download link to version 0.75.6

### DIFF
--- a/content/docs/deployment/quickstart/_index.md
+++ b/content/docs/deployment/quickstart/_index.md
@@ -207,7 +207,7 @@ shown below. This will download the binary and save it with the name
 `velociraptor`:
 
 ```sh
-wget -O velociraptor https://github.com/Velocidex/velociraptor/releases/download/v0.74/velociraptor-v0.74.1-linux-amd64
+wget -O velociraptor https://github.com/Velocidex/velociraptor/releases/download/v0.75/velociraptor-v0.75.6-linux-amd64
 ```
 
 Then make the downloaded file executable so that you can run it in subsequent


### PR DESCRIPTION
Version 0.74.1 is vulnerable to CVE-2025-6264 and CVE-2025-14728. Though users are told to check for the latest releases, many copy and run commands. In this case - leading them to install vulnerable software.