### PR TITLE
Fix: Correct JLECmd download URL and bump version to 1.5.1

### DIFF
--- a/content/exchange/artifacts/Windows.Forensics.Jumplists_JLECmd.yaml
+++ b/content/exchange/artifacts/Windows.Forensics.Jumplists_JLECmd.yaml
@@ -6,14 +6,14 @@ description: |
     * Created using @carlos_cajigas LECmd VQL as a quide.
     * JLECmd is a CLI tool for analyzing Custom Destinations jump list data. Learn more - https://github.com/EricZimmerman/JLECmd
 
-author: Orhan Emre @orhan_emre
+author: Orhan Emre @orhan_emre. Modified by Zach K. https://www.linkedin.com/in/zach-kal on 2026-02-11 to address 404-url and update JLE ver to 1.5.1.
 
 type: CLIENT
 
 tools:
   - name: JLECmd
-    url: https://download.mikestammer.com/net6/JLECmd.zip
-    version: 1.5.0
+    url: https://download.ericzimmermanstools.com/JLECmd.zip
+    version: 1.5.1
 
 
 parameters:


### PR DESCRIPTION
Update to Windows.Forensics.Jumplists_JLECmd

## Overview

This pull request updates the Windows.Forensics.Jumplists_JLECmd artifact definition to address the following issues

- Tool URL: Changed to https://download.ericzimmermanstools.com/LECmd.zip to resolve previous 404 errors.
- Tool version: update JLECmd to v 1.5.1 

## Motivation

These changes improve the reliability and usability of the JLECmd artifact, ensuring it works with the latest tool version.

This is a snippet demonstrating the url-404 issue

## This is a snippet demonstrating the url-404 issue

<img width="1654" height="176" alt="image" src="https://github.com/user-attachments/assets/fb281e0f-6234-4824-961f-dc5dfa6bd99e" />
