### PR TITLE
Fetch useful info from clients and store it as client metadata

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/content/exchange/artifacts/Generic.Client.ADStatus.yaml
+++ b/content/exchange/artifacts/Generic.Client.ADStatus.yaml
@@ -1,0 +1,114 @@
+name: Generic.Client.ADStatus
+author: Andreas Misje – @misje
+description: |
+  Get Active Directory join status from a computer. The information returned
+  depends on the operating system, but DomainJoined (boolean) and Domain is
+  returned for all. DomainJoined is always set. Domain is always uppercase.
+
+  On Linux, realm/sssd is used to query AD status/configuration. The following
+  columns are returned:
+
+    - _RealmType (e.g. "kerberos")
+    - _RealmName (e.g. "AD.EXAMPLE.ORG")
+    - Domain (e.g. "AD.EXAMPLE.ORG)
+    - AllowedUsers (e.g. ["bob"])
+    - AllowedGroups (e.g. ["it"])
+    - DomainJoined (boolean)
+
+  On Windows, `dsregcmd` is used to return AD status/configuration. Only a small
+  part of its output is returned:
+
+    - AzureAdJoined (boolean)
+    - EnterpriseJoined (boolean)
+    - DomainJoined (boolean)
+    - NetBIOS (e.g. "EXAMPLE")
+    - Domain (e.g. "AD.EXAMPLE.ORG)
+    - DeviceName (e.g. "DESKTOP-FOO")
+
+  On macOS, `dsconfigad` is used to return AD status/configuration:
+
+    - Domain (e.g. "AD.EXAMPLE.ORG")
+    - DeviceName (e.g. "DESKTOP-FOO")
+    - AdminGroups (e.g. ["it"])
+    - DomainJoined (boolean)
+
+type: CLIENT
+
+sources:
+  - query: |
+      LET Info <= SELECT OS
+        FROM info()
+
+      LET SplitString(String) = filter(regex='.+',
+                                       list=split(string=String, sep=', ?'))
+
+      LET LinuxStatus = SELECT
+          parse_string_with_regex(
+            string=Stdout,
+            regex=(''' +type: +(?P<_RealmType>.*)''', ''' +realm-name: +(?P<_RealmName>.*)''', ''' +domain-name: +(?P<Domain>.*)''', ''' +permitted-logins: +(?P<AllowedUsers>.*)''', ''' +permitted-groups: +(?P<AllowedGroups>.*)''', )) AS ADStatus
+        FROM execve(
+          argv=('realm', 'list'))
+
+      LET WindowsStatus = SELECT
+          parse_string_with_regex(
+            string=Stdout,
+            regex=('''(?s)Device State.+AzureAdJoined *: *(?P<AzureAdJoined>\S+)''', '''(?s)Device State.+EnterpriseJoined *: *(?P<EnterpriseJoined>\S+)''', '''(?s)Device State.+DomainJoined *: *(?P<DomainJoined>\S+)''', '''(?s)Device State.+DomainName *: *(?P<NetBIOS>\S+)''', '''(?s)Device State.+Device Name *: *(?P<DeviceName>\S+)''', )) AS ADStatus
+        FROM execve(
+          argv=('dsregcmd', '/status'))
+
+      LET DarwinStatus = SELECT
+          parse_string_with_regex(
+            string=Stdout,
+            regex=('''Active Directory Domain += +(?P<Domain>\S+)''', '''Computer Account += +(?P<DeviceName>\S+)\$''', ''' +Allowed admin groups += +(?P<AdminGroups>.+)''', )) AS ADStatus
+        FROM execve(
+          argv=('dsconfigad', '-show'))
+
+      LET ADDict = SELECT
+          ADStatus + dict(Domain=upcase(string=ADStatus.Domain)) AS ADStatus
+        FROM switch(
+          linux={
+          SELECT *
+          FROM if(
+            condition=Info[0].OS = 'linux',
+            then={
+          SELECT ADStatus + dict(
+                   DomainJoined=ADStatus != dict(),
+                   AllowedUsers=SplitString(String=ADStatus.AllowedUsers),
+                   AllowedGroups=SplitString(String=ADStatus.AllowedGroups)) AS ADStatus
+          FROM LinuxStatus
+        })
+        },
+          windows={
+          SELECT
+          *
+          FROM if(
+            condition=Info[0].OS = 'windows',
+            then={
+          SELECT
+          ADStatus + dict(
+            AzureAdJoined=ADStatus.AzureAdJoined = 'YES',
+            EnterpriseJoined=ADStatus.EnterpriseJoined = 'YES',
+            DomainJoined=ADStatus.DomainJoined = 'YES') +
+            parse_string_with_regex(
+              string=ADStatus.DeviceName,
+              regex='''^(?P<DeviceName>[^.]+)\.(?P<Domain>\S+)$''') AS ADStatus
+          FROM WindowsStatus
+        })
+        },
+          darwin={
+          SELECT
+          *
+          FROM if(
+            condition=Info[0].OS = 'darwin',
+            then={
+          SELECT
+          ADStatus + dict(
+            DomainJoined=ADStatus != dict(),
+            AdminGroups=SplitString(
+              String=ADStatus.AdminGroups)) AS ADStatus
+          FROM DarwinStatus
+        })
+        })
+
+      SELECT *
+      FROM foreach(row=ADDict, column='ADStatus')

--- a/content/exchange/artifacts/Generic.Client.ADStatus.yaml
+++ b/content/exchange/artifacts/Generic.Client.ADStatus.yaml
@@ -1,38 +1,39 @@
 name: Generic.Client.ADStatus
 author: Andreas Misje – @misje
 description: |
-  Get Active Directory join status from a computer. The information returned
-  depends on the operating system, but DomainJoined (boolean) and Domain is
-  returned for all. DomainJoined is always set. Domain is always uppercase.
+  Get Active Directory join status from a computer.
 
-  On Linux, realm/sssd is used to query AD status/configuration. The following
-  columns are returned:
+  `DomainJoined` (boolean) and `Domain` (uppercase) are returned on all
+  operating systems. Additional columns depend on the OS:
 
-    - _RealmType (e.g. "kerberos")
-    - _RealmName (e.g. "AD.EXAMPLE.ORG")
-    - Domain (e.g. "AD.EXAMPLE.ORG)
-    - AllowedUsers (e.g. ["bob"])
-    - AllowedGroups (e.g. ["it"])
-    - DomainJoined (boolean)
+  - **Linux**: uses `realm list` (realm/sssd). Adds `_RealmType`,
+    `_RealmName`, `AllowedUsers`, `AllowedGroups`.
+  - **Windows**: uses `dsregcmd /status`. Adds `AzureAdJoined`,
+    `EnterpriseJoined`, `NetBIOS`, `DeviceName`.
+  - **macOS**: uses `dsconfigad -show`. Adds `DeviceName`, `AdminGroups`.
 
-  On Windows, `dsregcmd` is used to return AD status/configuration. Only a small
-  part of its output is returned:
+  On Linux hosts without realm/sssd installed, `realm list` is absent and
+  the artifact returns `DomainJoined: false`. Treat that as "unknown" if
+  the deployment mixes hosts that may not have realm at all.
 
-    - AzureAdJoined (boolean)
-    - EnterpriseJoined (boolean)
-    - DomainJoined (boolean)
-    - NetBIOS (e.g. "EXAMPLE")
-    - Domain (e.g. "AD.EXAMPLE.ORG)
-    - DeviceName (e.g. "DESKTOP-FOO")
+  ## Use as part of client interrogation
 
-  On macOS, `dsconfigad` is used to return AD status/configuration:
+  This artifact is designed to be called from a custom override of
+  [`Generic.Client.Info`](/artifact_references/pages/generic.client.info/)
+  so that AD status is collected on every interrogation. Combined with
+  [`Server.Monitor.StoreClientInfo`](/exchange/artifacts/pages/server.monitor.storeclientinfo/),
+  the result can be saved as searchable client metadata such as
+  `ad_joined: true` or `ad_domain: AD.EXAMPLE.ORG`. See
+  [How can I automatically add & update client metadata?](/knowledge_base/tips/automating_metadata/)
+  for an in-depth walkthrough about how to save interrogation data as
+  client metadata.
 
-    - Domain (e.g. "AD.EXAMPLE.ORG")
-    - DeviceName (e.g. "DESKTOP-FOO")
-    - AdminGroups (e.g. ["it"])
-    - DomainJoined (boolean)
+  #metadata #activedirectory
 
 type: CLIENT
+
+implied_permissions:
+  - EXECVE
 
 sources:
   - query: |

--- a/content/exchange/artifacts/Generic.Client.Defender.Health.yaml
+++ b/content/exchange/artifacts/Generic.Client.Defender.Health.yaml
@@ -1,0 +1,150 @@
+name: Generic.Client.Defender.Health
+author: Andreas Misje – @misje
+description: |
+  Get MDATP health
+
+  Microsoft Defender for Endpoint Advanced Threat Protection is an EDR solution
+  for Windows, Darwin and Linux. This artifact retrieves all available information
+  about the agents's status and configuration. The artifact will fail if MDATP is
+  not installed on the endpoint.
+
+  The output from the MDATP status commands vary significantly between Windows
+  and Linux/Darwin. The output on Linux and Darwin are almost identical, with a
+  few exceptions:
+
+  Linux has these additional fields:
+
+    - behaviorMonitoring
+    - supplementaryEventsSubsystem
+
+  Darwin has these additional fields:
+
+    - deviceControlEnforcementLevel
+    - ecsConfigurationIds
+    - fullDiskAccessEnabled
+    - networkEventsSubsystem
+    - tamperProtection
+    - troubleshootingMode
+
+  The notebook suggestion "Common MDATP health information" provides a nice
+  summary of information of fields present in at least Windows and one of Linux
+  and Darwin.
+
+type: CLIENT
+
+implied_permissions:
+  - EXECVE
+
+sources:
+  - query: |
+      LET Info <= SELECT OS
+        FROM info()
+
+      SELECT *
+      FROM if(
+        condition=Info[0].OS = 'linux',
+        then={
+          SELECT parse_json(data=Stdout) AS MDATPHealth
+          FROM execve(argv=['/usr/bin/mdatp', 'health', '--output', 'json'])
+        },
+        else=if(
+          condition=Info[0].OS = 'darwin',
+          then={
+          SELECT parse_json(data=Stdout) AS MDATPHealth
+          FROM execve(argv=['/usr/local/bin/mdatp', 'health', '--output', 'json'])
+        },
+          else=if(
+            condition=Info[0].OS = 'windows',
+            then={
+          SELECT
+          to_dict(item={
+          SELECT _key,
+                 _value
+          FROM parse_records_with_regex(
+            file=Stdout,
+            accessor='data',
+            regex='''^\s*(?P<_key>\S+)\s+:\s+(?P<_value>[^\r\n]+)''')
+        }) + dict(
+            edrMachineId=read_file(
+              accessor='reg',
+              filename='''HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Advanced Threat Protection\senseId''')) AS MDATPHealth
+          FROM Artifact.Windows.System.PowerShell(
+            Command='Get-MpComputerStatus')
+        })))
+
+    notebook:
+      - name: Common MDATP health information
+        type: vql_suggestion
+        template: |
+          /*
+          # Common MDATP health information
+          */
+          LET ColumnTypes <= dict(`ClientId`='client')
+
+          LET S = scope()
+
+          LET Result <= SELECT
+              ClientId,
+              S.Fqdn || client_info(client_id=ClientId).os_info.fqdn AS Fqdn,
+              S.MDATPHealth || dict() AS D
+            FROM source()
+
+          SELECT *
+          FROM foreach(
+            row=Result,
+            query={
+              SELECT *
+              FROM if(
+                condition='AMEngineVersion' IN D,
+                then={
+              SELECT
+              ClientId,
+              Fqdn,
+              D.edrMachineId AS edrMachineId,
+              D.AMProductVersion AS appVersion,
+              D.AMEngineVersion AS engineVersion,
+              D.AntivirusSignatureVersion AS definitionsVersion,
+              timestamp(string=D.AntivirusSignatureLastUpdated) AS definitionsUpdated,
+              if(condition=D.DefenderSignaturesOutOfDate = NULL,
+                  then=NULL,
+                  else=D.DefenderSignaturesOutOfDate != 'False') AS definitionsUpToDate,
+              if(condition=D.BehaviorMonitorEnabled = NULL,
+                  then=NULL,
+                  else=D.BehaviorMonitorEnabled = 'True') AS behaviorMonitoringEnabled,
+              if(condition=D.RealTimeProtectionEnabled = NULL,
+                  then=NULL,
+                  else=D.RealTimeProtectionEnabled = 'True') AS realTimeProtectionEnabled,
+              if(
+                condition=D.IsTamperProtected = NULL,
+                then=NULL,
+                else=D.IsTamperProtected = 'True') AS tamperProtectionEnabled,
+              if(
+                condition=D.TroubleShootingMode = NULL,
+                then=NULL,
+                else=D.TroubleShootingMode != 'Disabled') AS troubleshootingModeEnabled
+              FROM scope()
+            },
+                else={
+              SELECT
+              ClientId,
+              Fqdn,
+              D.edrMachineId AS edrMachineId,
+              D.appVersion AS appVersion,
+              D.engineVersion AS engineVersion,
+              D.definitionsVersion AS definitionsVersion,
+              timestamp(
+                epoch=D.definitionsUpdated) AS definitionsUpdated,
+              if(
+                condition=D.definitionsStatus.`$type` = NULL,
+                then=NULL,
+                else=D.definitionsStatus.`$type` = 'upToDate') AS definitionsUpToDate,
+              // Not available in Darwin:
+              D.behaviorMonitoring.displayValue AS behaviorMonitoringEnabled,
+              D.realTimeProtectionEnabled.value AS realTimeProtectionEnabled,
+              // Not available in Linux:
+              D.tamperProtection.displayValue AS tamperProtectionEnabled,
+              // Not available in Linux:
+              D.troubleshootingMode AS troubleshootingModeEnabled
+              FROM scope()
+            })
+            })

--- a/content/exchange/artifacts/Generic.Client.Defender.Health.yaml
+++ b/content/exchange/artifacts/Generic.Client.Defender.Health.yaml
@@ -1,34 +1,54 @@
 name: Generic.Client.Defender.Health
 author: Andreas Misje – @misje
 description: |
-  Get MDATP health
+  Get Microsoft Defender for Endpoint (MDATP) health and configuration.
 
-  Microsoft Defender for Endpoint Advanced Threat Protection is an EDR solution
-  for Windows, Darwin and Linux. This artifact retrieves all available information
-  about the agents's status and configuration. The artifact will fail if MDATP is
-  not installed on the endpoint.
+  MDATP is Microsoft's EDR product for Windows, macOS and Linux. This
+  artifact retrieves all available agent status and configuration via the
+  platform-native interface: `mdatp health --output json` on Linux and
+  macOS, `Get-MpComputerStatus` through
+  [`Windows.System.PowerShell`](/artifact_references/pages/windows.system.powershell/)
+  on Windows.
 
-  The output from the MDATP status commands vary significantly between Windows
-  and Linux/Darwin. The output on Linux and Darwin are almost identical, with a
-  few exceptions:
+  A single row is returned with a dict called `MDATPHealth` whose
+  shape differs across platforms. Linux and macOS are nearly
+  identical; Windows differs significantly. Platform-specific extras:
 
-  Linux has these additional fields:
+  Linux:
 
-    - behaviorMonitoring
-    - supplementaryEventsSubsystem
+  - `behaviorMonitoring`
+  - `supplementaryEventsSubsystem`
 
-  Darwin has these additional fields:
+  macOS:
 
-    - deviceControlEnforcementLevel
-    - ecsConfigurationIds
-    - fullDiskAccessEnabled
-    - networkEventsSubsystem
-    - tamperProtection
-    - troubleshootingMode
+  - `deviceControlEnforcementLevel`
+  - `ecsConfigurationIds`
+  - `fullDiskAccessEnabled`
+  - `networkEventsSubsystem`
+  - `tamperProtection`
+  - `troubleshootingMode`
 
-  The notebook suggestion "Common MDATP health information" provides a nice
-  summary of information of fields present in at least Windows and one of Linux
-  and Darwin.
+  Windows values are parsed from text output and arrive as strings
+  (e.g. the literal `'True'`, not the boolean `true`). Linux and macOS
+  values are properly typed JSON. The notebook suggestion **Common
+  MDATP health information** normalises a useful subset across all
+  three platforms.
+
+  ## Use as part of client interrogation
+
+  Although useful on its own to gather MDATP status from hosts, this
+  artifact can also be called from a custom override of
+  [`Generic.Client.Info`](/artifact_references/pages/generic.client.info/).
+  Combined with
+  [`Server.Monitor.StoreClientInfo`](/exchange/artifacts/pages/server.monitor.storeclientinfo/),
+  selected fields can be saved as client metadata. In particular,
+  `edrMachineId` can be used to identify the client in MDATP, and tie
+  the client ID to machines in Microsoft Graph API queries. See
+  [How can I automatically add & update client metadata?](/knowledge_base/tips/automating_metadata/)
+  for an in-depth walkthrough about how to save interrogation data as
+  client metadata.
+
+  #mdatp #metadata
 
 type: CLIENT
 

--- a/content/exchange/artifacts/Generic.Client.HW.Identification.yaml
+++ b/content/exchange/artifacts/Generic.Client.HW.Identification.yaml
@@ -1,0 +1,183 @@
+name: Generic.Client.HW.Identification
+author: Andreas Misje – @misje
+description: |
+   Extract product serial and other identification strings from the system.
+
+   One column is returned, SystemInfo, a dict with all available information.
+   On MacOS, only manufacturer, model and serial is available. Example values:
+
+   Lenovo T14 Gen 2i:
+
+   | Key | Example value |
+   | --- | ------------- |
+   | product_family | Thinkpad T14 Gen 2i |
+   | product_name | 20W00126MX |
+   | product_sku | LENOVO_MT_20W0_BU_Think_FM_ThinkPad T14 Gen 2i |
+   | product_serial | xxxxxxxx |
+   | product_uuid | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx |
+   | product_manufacturer | LENOVO |
+   | product_version | Thinkpad T14 Gen 2i |
+   | board_name | 20W00126MX |
+   | board_serial | xxxxxxxxxxx |
+   | board_manufacturer | LENOVO |
+   | board_version | SDK0T76538 WIN |
+   | chassis_asset_tag | No Asset Information |
+   | chassis_serial | xxxxxxxx |
+   | chassis_manufacturer | LENOVO |
+   | chassis_version | None |
+
+   Dell Latitude 7420:
+
+   | Key | Example value |
+   | --- | ------------- |
+   | product_family | Latitude |
+   | product_name | Latitude 7420 |
+   | product_sku | 0A36 |
+   | product_serial | xxxxxxx |
+   | product_uuid | xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx |
+   | product_manufacturer | |
+   | product_version | |
+   | board_name | 07MHG4 |
+   | board_serial | xxxxxxxx/xxxxxxxxxxxxxxx |
+   | board_manufacturer | Dell Inc. |
+   | board_version | A02 |
+   | chassis_asset_tag | 57182 |
+   | chassis_serial | xxxxxxx |
+   | chassis_manufacturer | Dell Inc. |
+   | chassis_version | |
+
+   Raspberry Pi:
+
+   | Key | Example value |
+   | --- | ------------- |
+   | firmware_version | Raspberry Pi 4 Model B Rev 1.2 |
+   | firmware_serial | xxxxxxxxxxxxxxxx |
+
+   MacBook Pro:
+
+   | Key | Example value |
+   | --- | ------------- |
+   | product_name | Mac15,6 |
+   | product_serial | xxxxxxxxxx |
+   | product_manufacturer | Apple Inc. |
+
+type: CLIENT
+
+implied_permissions:
+  - EXECVE
+
+sources:
+   - query: |
+       LET Info <= SELECT OS
+         FROM info()
+
+       LET IsWin <= Info[0].OS = 'windows'
+
+       LET IsLin <= Info[0].OS = 'linux'
+
+       LET IsMac <= Info[0].OS = 'darwin'
+
+       LET WinInfo = SELECT {
+           SELECT dict(product_family=SystemFamily,
+                       product_name=Model,
+                       product_sku=SystemSKUNumber) AS Info
+           FROM wmi(query='select * from Win32_ComputerSystem')
+           } AS ComputerSystem,
+                            {
+           SELECT dict(product_serial=IdentifyingNumber,
+                       product_uuid=UUID,
+                       product_manufacturer=Vendor,
+                       product_version=Version) AS Info
+           FROM wmi(query='select * from Win32_ComputerSystemProduct')
+           } AS ComputerSystemProduct,
+                            {
+           SELECT dict(board_name=Product,
+                       board_serial=SerialNumber,
+                       board_manufacturer=Manufacturer,
+                       board_version=Version) AS Info
+           FROM wmi(query='select * from Win32_BaseBoard')
+           } AS BaseBoard,
+                            {
+           SELECT dict(chassis_asset_tag=SMBIOSAssetTag,
+                       chassis_serial=SerialNumber,
+                       chassis_manufacturer=Manufacturer,
+                       chassis_version=Version) AS Info
+           FROM wmi(query='SELECT * FROM Win32_SystemEnclosure')
+           } AS SystemEnclosure
+         FROM scope()
+
+       LET SysInfoDict = SELECT Info AS SystemInfo
+         FROM if(
+           condition=IsLin,
+           then={
+           SELECT
+           dict(
+             product_family=read_file(filename='/sys/class/dmi/id/product_family')[:-1],
+             product_name=read_file(
+               filename='/sys/class/dmi/id/product_name')[:-1],
+             product_serial=read_file(
+               filename='/sys/class/dmi/id/product_serial')[:-1],
+             product_sku=read_file(
+               filename='/sys/class/dmi/id/product_sku')[:-1],
+             product_uuid=read_file(
+               filename='/sys/class/dmi/id/product_uuid')[:-1],
+             product_version=read_file(
+               filename='/sys/class/dmi/id/product_version')[:-1],
+             board_name=read_file(
+               filename='/sys/class/dmi/id/board_name')[:-1],
+             board_serial=read_file(
+               filename='/sys/class/dmi/id/board_serial')[:-1],
+             board_manufacturer=read_file(
+               filename='/sys/class/dmi/id/board_vendor')[:-1],
+             board_version=read_file(
+               filename='/sys/class/dmi/id/board_version')[:-1],
+             chassis_asset_tag=read_file(
+               filename='/sys/class/dmi/id/chassis_asset_tag')[:-1],
+             chassis_serial=read_file(
+               filename='/sys/class/dmi/id/chassis_serial')[:-1],
+             chassis_manufacturer=read_file(
+               filename='/sys/class/dmi/id/chassis_vendor')[:-1],
+             chassis_version=read_file(
+               filename='/sys/class/dmi/id/chassis_version')[:-1],
+             // Useful on devices like Raspberry Pi, where no other information is available:
+             firmware_version=read_file(
+               filename='/sys/firmware/devicetree/base/model')[:-1],
+             // Useful on devices like Raspberry Pi, where no other information is available:
+             firmware_serial=read_file(
+               filename='/sys/firmware/devicetree/base/serial-number')[:-1]) AS Info
+           FROM scope()
+         },
+           else=if(
+             condition=IsMac,
+             then={
+           SELECT
+           parse_string_with_regex(
+             string=Stdout,
+             regex=('"manufacturer" = <"(?P<product_manufacturer>[^"]+)">', '"model" = <"(?P<product_name>[^"]+)">', '"IOPlatformSerialNumber" = "(?P<product_serial>[^"]+)"')) AS Info
+           FROM execve(
+             argv=['ioreg', '-c', 'IOPlatformExpertDevice', '-d', 2])
+         },
+             else=if(
+               condition=IsWin,
+               then={
+           SELECT
+           ComputerSystem + ComputerSystemProduct + BaseBoard +
+             SystemEnclosure AS Info
+           FROM WinInfo
+         })))
+
+       // This is a very simple attempt to detect whether the computer is virtual.
+       // Detecting this is really hard, sometimes impossible, but this may still
+       // be useful:
+       SELECT
+           *, product_name =~ '''(?i)\b(virtualbox|vmware|kvm|qemu|hyper[- ]?v|xen|parallels|bhyve|openstack|cloudstack|bochs|amazon ec2|azure|google compute engine|nutanix|proxmox|virtio|vultr|digitalocean|oracle cloud|microsoft virtual machine|virtual machine|standard pc)\b''' AS virtual
+       FROM foreach(
+         row=SysInfoDict,
+         column='SystemInfo')
+
+     notebook:
+       - name: As dict
+         type: vql_suggestion
+         template: |
+           SELECT _value AS SystemInfo
+           FROM items(item={ SELECT * FROM source() })

--- a/content/exchange/artifacts/Generic.Client.HW.Identification.yaml
+++ b/content/exchange/artifacts/Generic.Client.HW.Identification.yaml
@@ -3,10 +3,33 @@ author: Andreas Misje – @misje
 description: |
    Extract product serial and other identification strings from the system.
 
-   One column is returned, SystemInfo, a dict with all available information.
-   On MacOS, only manufacturer, model and serial is available. Example values:
+   One column `SystemInfo` is returned: a dict with all available fields.
+   Sources vary by platform:
 
-   Lenovo T14 Gen 2i:
+   - **Linux**: reads DMI tables from `/sys/class/dmi/id/*`, plus
+     `/sys/firmware/devicetree/base/*` to catch single-board computers
+     (Raspberry Pi etc.) where DMI is absent.
+   - **Windows**: uses WMI: `Win32_ComputerSystem`,
+     `Win32_ComputerSystemProduct`, `Win32_BaseBoard`,
+     `Win32_SystemEnclosure`.
+   - **macOS**: uses `ioreg -c IOPlatformExpertDevice`. Only
+     `product_manufacturer`, `product_name` and `product_serial` are
+     available.
+
+   A second column `virtual` is added, a best-effort boolean derived
+   from `product_name` that recognises common hypervisors and cloud
+   providers (VirtualBox, VMware, KVM/QEMU, Hyper-V, Xen, Parallels,
+   EC2, Azure, GCE etc.). The check is informational; systems can
+   easily evade this check, and some VMs does not provide any HW
+   information at all. `true` likely means that a host is virtual, but
+   `false` should not be trusted.
+
+   On hosts without DMI tables, the `firmware_*` fields provide an
+   alternative to identify the system.
+
+   {{% expand "Example values across platforms" %}}
+
+   Lenovo T14 Gen 2i (Linux):
 
    | Key | Example value |
    | --- | ------------- |
@@ -26,7 +49,10 @@ description: |
    | chassis_manufacturer | LENOVO |
    | chassis_version | None |
 
-   Dell Latitude 7420:
+   Dell Latitude 7420 (Linux). Note empty `product_manufacturer`/
+   `product_version` — Dell ships those blank on some models, so always
+   verify the source field is populated before relying on it for
+   metadata:
 
    | Key | Example value |
    | --- | ------------- |
@@ -46,20 +72,40 @@ description: |
    | chassis_manufacturer | Dell Inc. |
    | chassis_version | |
 
-   Raspberry Pi:
+   Raspberry Pi (Linux, no DMI — firmware fields only):
 
    | Key | Example value |
    | --- | ------------- |
    | firmware_version | Raspberry Pi 4 Model B Rev 1.2 |
    | firmware_serial | xxxxxxxxxxxxxxxx |
 
-   MacBook Pro:
+   MacBook Pro (macOS):
 
    | Key | Example value |
    | --- | ------------- |
    | product_name | Mac15,6 |
    | product_serial | xxxxxxxxxx |
    | product_manufacturer | Apple Inc. |
+
+   Some manufacturers, like MSI, will refer to a serial number that is
+   not obtainable anywhere on the host.
+
+   {{% /expand %}}
+
+   ## Use as part of client interrogation
+
+   This artifact is designed to be called from a custom override of
+   [`Generic.Client.Info`](/artifact_references/pages/generic.client.info/)
+   so that hardware identification is collected on every interrogation.
+   Combined with
+   [`Server.Monitor.StoreClientHWInfo`](/exchange/artifacts/pages/server.monitor.storeclienthwinfo/),
+   you can store key hardware information, like serial, as client
+   metadata. See
+   [How can I automatically add & update client metadata?](/knowledge_base/tips/automating_metadata/)
+   for an in-depth walkthrough about how to save interrogation data as
+   client metadata.
+
+   #metadata
 
 type: CLIENT
 

--- a/content/exchange/artifacts/Server.Monitor.StoreClientHWInfo.yaml
+++ b/content/exchange/artifacts/Server.Monitor.StoreClientHWInfo.yaml
@@ -1,0 +1,142 @@
+name: Server.Monitor.StoreClientHWInfo
+author: Andreas Misje – @misje
+description: |
+  Save HW identification data from client interrogation as client metadata.
+
+  This artifact listens to flow completions, typically Custom.Generic.Client.Info,
+  your own override of the interrogation artifact, and extracts hardware information
+  gathered in the interrogation. The artifact used to provide this information
+  is expected to be Generic.Client.HW.Identification, provided as a source by
+  the customisable name HWIdentificationSource. In other words, you have to add
+  a new source to your Custom.Generic.Client.Info artifact and call
+  Generic.Client.HW.Identification for this server event artifact to be useful.
+  However, since this artifact is highly customisable, you may use it to set
+  any kind of metadata provided by a interrogation artifact source. Simply
+  adjust the parameters to your needs, ignore the serial settings, and adjust
+  HWInfoMetadata as needed.
+
+  The primary use case for this artifact is to store the serial number of the
+  client as client metadata. This allows you to quickly look up clients by their
+  serial number if you add "serial" as an indexed field. Additional hardware info,
+  like the manufacturer, product name or model, may also be added as metadata.
+  Only unique, relevant metadata is useful for indexed searching, but additional
+  hardware identification could be handy anyway.
+
+  See also Server.Monitor.StoreClientInfo for a similar artifact for storing
+  any metadata from any source in the interrogation artifact.
+
+type: SERVER_EVENT
+
+parameters:
+  - name: InterrogationArtifact
+    type: regex
+    description: |
+      Name of the client artifact to watch
+    default: Custom.Generic.Client.Info
+
+  - name: HWIdentificationSource
+    description: |
+      Source in InterrogationArtifact that contains hardware information
+    default: HWIdentification
+
+  - name: SerialColumn
+    description: |
+      Name of column containing the serial number used to find the device in
+      Snipe-IT. The default behaviour is to pick the first non-empty value in
+      product_serial, board_serial, and lastly, firmware_serial. The order of
+      choices matter.
+    type: multichoice
+    choices:
+      - product_serial
+      - board_serial
+      - chassis_serial
+      - firmware_serial
+    default: '["product_serial", "board_serial", "firmware_serial"]'
+
+  - name: SerialMetadataField
+    description: |
+      Name of the metadata field that will store the serial number (from
+      SerialColumn).
+    default: serial
+
+  - name: SerialIgnore
+    description: |
+      Serial values to ignore, typically defaults set on motherboards.
+    type: regex
+    default: '^(System Serial Number|System Version|Default string|0|None|)$'
+
+  - name: HWInfoMetadata
+    description: |
+      Additional columns from InterrogationArtifact/HWIdentificationSource that will be
+      set as client metadata (SerialColumn/SerialMetadataField is always set).
+      Specify the column from the HWIdentification source in "Field", and an
+      optional alias, used as metadata name, in "Alias".
+    type: csv
+    default: |
+      Field,Alias
+      board_manufacturer,manufacturer
+      product_name,
+
+  - name: KeepEmptyValues
+    description: |
+      If true, an empty value will be stored as metadata. If false, the metadata
+      will not be set at all. Note that if a metadata value was previously empty,
+      this will not remove that value. Empty/null serials are ignored.
+    type: bool
+    default: false
+
+sources:
+  - query: |
+      LET HWInfo = SELECT *
+        FROM foreach(row={
+          SELECT *
+          FROM watch_monitoring(artifact='System.Flow.Completion')
+          WHERE Flow.artifacts_with_results =~ InterrogationArtifact
+        },
+                     query={
+          SELECT ClientId,
+                 *
+          FROM source(client_id=ClientId,
+                      flow_id=Flow.session_id,
+                      artifact=InterrogationArtifact,
+                      source=HWIdentificationSource)
+        })
+
+      // With HW info as dict:
+      LET HWInfoDict = SELECT _value.ClientId AS ClientId,
+                              _value - dict(ClientId=NULL, _Source=NULL) AS Data
+        FROM items(item={ SELECT * FROM HWInfo })
+
+      LET SerialValue(Data) = SELECT _value
+        FROM items(item=Data)
+        WHERE _key IN SerialColumn
+         AND NOT _value =~ SerialIgnore
+
+      LET NullOrEmpty(Value) = Value = NULL OR Value = ""
+
+      LET SelectedMetadata = SELECT *
+        FROM foreach(row=HWInfoDict,
+                     query={
+          SELECT ClientId,
+                 to_dict(item={
+          SELECT *
+          FROM foreach(row=HWInfoMetadata,
+                       query={
+          SELECT Alias || Field AS _key,
+                 get(item=Data, field=Field) AS _value
+          FROM scope()
+          WHERE KeepEmptyValues OR (_value != NULL
+             AND len(list=str(str=_value)))
+        })
+        }) + if(condition=NOT NullOrEmpty(Value=SerialValue(Data=Data)[0]._value),
+                then=set(item=dict(),
+                         field=SerialMetadataField,
+                         value=SerialValue(Data=Data)[0]._value),
+                else=dict()) AS Metadata
+          FROM scope()
+        })
+
+      // Set the metadata and return the dict of data, as well as the the
+      // client_set_metadata() result:
+      SELECT *, client_set_metadata(client_id=ClientId, metadata=Metadata) AS Updated
+      FROM SelectedMetadata

--- a/content/exchange/artifacts/Server.Monitor.StoreClientHWInfo.yaml
+++ b/content/exchange/artifacts/Server.Monitor.StoreClientHWInfo.yaml
@@ -1,29 +1,78 @@
 name: Server.Monitor.StoreClientHWInfo
 author: Andreas Misje – @misje
 description: |
-  Save HW identification data from client interrogation as client metadata.
+  Save hardware identification data from client interrogation as
+  client metadata.
 
-  This artifact listens to flow completions, typically Custom.Generic.Client.Info,
-  your own override of the interrogation artifact, and extracts hardware information
-  gathered in the interrogation. The artifact used to provide this information
-  is expected to be Generic.Client.HW.Identification, provided as a source by
-  the customisable name HWIdentificationSource. In other words, you have to add
-  a new source to your Custom.Generic.Client.Info artifact and call
-  Generic.Client.HW.Identification for this server event artifact to be useful.
-  However, since this artifact is highly customisable, you may use it to set
-  any kind of metadata provided by a interrogation artifact source. Simply
-  adjust the parameters to your needs, ignore the serial settings, and adjust
-  HWInfoMetadata as needed.
+  The primary use case is to store a stable device serial number as
+  the `serial` metadata field. Indexing `serial` makes clients quickly
+  searchable from the GUI by their hardware identity. Additional
+  hardware fields, like manufacturer, product name and model, may also
+  be set as metadata for non-indexed lookup.
 
-  The primary use case for this artifact is to store the serial number of the
-  client as client metadata. This allows you to quickly look up clients by their
-  serial number if you add "serial" as an indexed field. Additional hardware info,
-  like the manufacturer, product name or model, may also be added as metadata.
-  Only unique, relevant metadata is useful for indexed searching, but additional
-  hardware identification could be handy anyway.
+  ## Setup requirement
 
-  See also Server.Monitor.StoreClientInfo for a similar artifact for storing
-  any metadata from any source in the interrogation artifact.
+  This artifact reads from a source named `HWIdentification` (override
+  via `HWIdentificationSource`) inside the interrogation artifact named
+  by `InterrogationArtifact` (default `Custom.Generic.Client.Info`).
+  You need to add a source by that name to your
+  [`Generic.Client.Info`](/artifact_references/pages/generic.client.info/)
+  override that calls
+  [`Generic.Client.HW.Identification`](/exchange/artifacts/pages/generic.client.hw.identification/):
+
+  ```yaml
+  - name: HWIdentification
+    query: SELECT * FROM Artifact.Generic.Client.HW.Identification()
+  ```
+
+  ## Stable serial selection
+
+  Hardware serials are reported under several names depending on the
+  vendor and platform: `product_serial`, `board_serial`,
+  `chassis_serial`, `firmware_serial`. Some are reliable; others are
+  blank or contain BIOS placeholders such as `Default string` or
+  `System Serial Number`. `SerialColumn` lets you declare a fallback
+  order: the first candidate with a non-empty, non-ignored (by
+  `SerialIgnore`) value is picked. `SerialIgnore` is a regex that filters
+  out known placeholder values.
+
+
+  ## Customisation
+
+  Use `HWInfoMetadata` to select which hardware information to store,
+  and under what name, e.g.
+
+  | Field | Alias |
+  | ----- | ----- |
+  | `board_manufacturer` | `manufacturer`
+  | `product_name` | |
+  | `virtual` | |
+  | `chassis_asset_tag` | `asset_tag` |
+
+  If you modify/extend
+  [`Generic.Client.HW.Identification`](/exchange/artifacts/pages/generic.client.hw.identification/),
+  remember to still produce a single row, and simply add new columns
+  to refer to in `HWInfoMetadata`.
+
+  If you need to store results from collections other than hardware
+  information like
+  [`Generic.Client.HW.Identification`](/exchange/artifacts/pages/generic.client.hw.identification/),
+  use
+  [`Server.Monitor.StoreClientInfo`](/exchange/artifacts/pages/server.monitor.storeclientinfo/)
+  instead.
+
+  ## See also
+
+  - [`Server.Monitor.StoreClientInfo`](/exchange/artifacts/pages/server.monitor.storeclientinfo/):
+    sibling artifact for storing arbitrary metadata from any
+    interrogation source (no serial-specific behaviour)
+  - [`Generic.Client.HW.Identification`](/exchange/artifacts/pages/generic.client.hw.identification/):
+    the producing artifact this one expects to consume
+  - [How can I automatically add & update client metadata?](/knowledge_base/tips/automating_metadata/):
+    in-depth walkthrough about how to save interrogation data as
+    client metadata
+
+  #metadata #automation
 
 type: SERVER_EVENT
 
@@ -107,10 +156,17 @@ sources:
                               _value - dict(ClientId=NULL, _Source=NULL) AS Data
         FROM items(item={ SELECT * FROM HWInfo })
 
-      LET SerialValue(Data) = SELECT _value
-        FROM items(item=Data)
-        WHERE _key IN SerialColumn
-         AND NOT _value =~ SerialIgnore
+      // Walk SerialColumn in declared priority order and return the first
+      // candidate field in Data with a non-empty, non-ignored value.
+      LET SerialValue(Data) = SELECT Value
+        FROM foreach(row=SerialColumn,
+                     query={
+          SELECT get(item=Data, field=_value) AS Value
+          FROM scope()
+        })
+        WHERE Value
+         AND NOT str(str=Value) =~ SerialIgnore
+        LIMIT 1
 
       LET NullOrEmpty(Value) = Value = NULL OR Value = ""
 
@@ -128,15 +184,23 @@ sources:
           WHERE KeepEmptyValues OR (_value != NULL
              AND len(list=str(str=_value)))
         })
-        }) + if(condition=NOT NullOrEmpty(Value=SerialValue(Data=Data)[0]._value),
+        }) + if(condition=NOT NullOrEmpty(Value=SerialValue(Data=Data)[0].Value),
                 then=set(item=dict(),
                          field=SerialMetadataField,
-                         value=SerialValue(Data=Data)[0]._value),
+                         value=SerialValue(Data=Data)[0].Value),
                 else=dict()) AS Metadata
           FROM scope()
         })
 
-      // Set the metadata and return the dict of data, as well as the the
+      // Set the metadata and return the dict of data, as well as the
       // client_set_metadata() result:
-      SELECT *, client_set_metadata(client_id=ClientId, metadata=Metadata) AS Updated
-      FROM SelectedMetadata
+      // Do not store an empty dict. This has proved to cause issues:
+      LET SetMetadata = SELECT *, if(condition=Metadata,
+                                     then=client_set_metadata(
+                                       client_id=ClientId,
+                                       metadata=Metadata),
+                                     else=false) AS Updated
+        FROM SelectedMetadata
+
+      SELECT *
+      FROM SetMetadata

--- a/content/exchange/artifacts/Server.Monitor.StoreClientInfo.yaml
+++ b/content/exchange/artifacts/Server.Monitor.StoreClientInfo.yaml
@@ -1,0 +1,111 @@
+name: Server.Monitor.StoreClientInfo
+author: Andreas Misje – @misje
+description: |
+  Save data from client interrogation as client metadata.
+
+  This artifact listens for flow completions, typically Custom.Generic.Client.Info,
+  your own override of the interrogation artifact, and extracts any information
+  gathered in the interrogation.
+
+  The primary use case for this artifact is to any useful information about the
+  client as metadata so that it can be indexed and search for, e.g. "OS: windows",
+  "arch: amd64", "dual_boot: true", "ad_joined: false" etc.
+
+  NOTE: The sources referred to in InfoMetadata should only return a single line.
+  If more lines are returned, only the first line is used.
+
+  See also Server.Monitor.StoreClientHWInfo.
+
+type: SERVER_EVENT
+
+parameters:
+  - name: InterrogationArtifact
+    type: regex
+    description: |
+      Name of the client artifact to watch
+    default: Custom.Generic.Client.Info
+
+  - name: InfoMetadata
+    description: |
+      The artifact source (e.g. BasicInformation), the field to save, and an
+      optional alias to give the field as a metadata name
+    type: csv
+    default: |
+      Source,Field,Alias
+      BasicInformation,OS,os
+      BasicInformation,Architecture,arch
+
+  - name: KeepEmptyValues
+    description: |
+      If true, an empty value will be stored as metadata. If false, the metadata
+      will not be set at all. Note that if a metadata value was previously empty,
+      this will not remove that value.
+    type: bool
+    default: false
+
+sources:
+  - query: |
+      LET ExtractSource(Artifact) = regex_replace(
+          re='[^/]+(?:/(?P<Source>.+))?',
+          replace='$1',
+          source=Artifact)
+
+      LET Interrogation = SELECT *
+        FROM foreach(row={
+          SELECT *
+          FROM watch_monitoring(artifact='System.Flow.Completion')
+          WHERE Flow.artifacts_with_results =~ InterrogationArtifact
+        },
+                     query={
+          SELECT *
+          FROM foreach(row=Flow.artifacts_with_results,
+                       query={
+          SELECT ExtractSource(Artifact=_value) AS _Source,
+                 ClientId,
+                 *
+          FROM source(client_id=ClientId,
+                      flow_id=Flow.session_id,
+                      artifact=InterrogationArtifact,
+                      source=ExtractSource(Artifact=_value))
+          WHERE ExtractSource(Artifact=_value) IN InfoMetadata.Source
+          GROUP BY _Source
+        })
+        })
+
+      // With info as dict:
+      LET InfoDict = SELECT _value.ClientId AS ClientId,
+                            _value._Source AS _Source,
+                            _value AS Data
+        FROM items(item={ SELECT * FROM Interrogation })
+
+      LET SelectedMetadata = SELECT *
+        FROM foreach(row=InfoDict,
+                     query={
+          SELECT ClientId,
+                 to_dict(item={
+          SELECT *
+          FROM foreach(row=InfoMetadata,
+                       query={
+          SELECT Alias || Field AS _key,
+                 get(item=Data, member=Field) AS _value
+          FROM scope()
+          WHERE _Source = Source
+           AND (KeepEmptyValues OR (_value != NULL
+                    AND len(list=str(str=_value))))
+        })
+        }) - dict(ClientId=NULL, _Source=NULL) AS Metadata
+          FROM scope()
+        })
+
+      // Set the metadata and return the dict of data, as well as the the
+      // client_set_metadata() result:
+      // Do not store an empty dict. This has proved to cause issues:
+      LET SetMetadata = SELECT *, if(condition=Metadata,
+                                     then=client_set_metadata(
+                                       client_id=ClientId,
+                                       metadata=Metadata),
+                                     else=false) AS Updated
+        FROM SelectedMetadata
+
+      SELECT *
+      FROM SetMetadata

--- a/content/exchange/artifacts/Server.Monitor.StoreClientInfo.yaml
+++ b/content/exchange/artifacts/Server.Monitor.StoreClientInfo.yaml
@@ -3,18 +3,42 @@ author: Andreas Misje – @misje
 description: |
   Save data from client interrogation as client metadata.
 
-  This artifact listens for flow completions, typically Custom.Generic.Client.Info,
-  your own override of the interrogation artifact, and extracts any information
-  gathered in the interrogation.
+  This artifact listens for completions of an interrogation artifact —
+  typically `Custom.Generic.Client.Info`, your own override of
+  [`Generic.Client.Info`](/artifact_references/pages/generic.client.info/)
+  — and stores selected fields from the result as client metadata, so
+  they can be indexed and searched.
 
-  The primary use case for this artifact is to any useful information about the
-  client as metadata so that it can be indexed and search for, e.g. "OS: windows",
-  "arch: amd64", "dual_boot: true", "ad_joined: false" etc.
+  Field selection is controlled by `InfoMetadata`, a CSV parameter
+  mapping `Source` (the artifact source name, e.g. `BasicInformation`)
+  and `Field` (the column to read) to an `Alias` used as the metadata
+  key. If `Alias` is empty, the original `Field` is used. Example:
 
-  NOTE: The sources referred to in InfoMetadata should only return a single line.
-  If more lines are returned, only the first line is used.
+  | Source | Field | Alias |
+  | ------ | ----- | ----- |
+  | `BasicInformation` | `OS`  | `os` |
+  | `BasicInformation` | `Architecture` | `arch` |
+  | `ADStatus` | `DomainJoined` | `ad_joined` |
+  | `MDATPHealth` | `MDATPHealth.edrMachineId` | `defender_id` |
 
-  See also Server.Monitor.StoreClientHWInfo.
+  `Field` can refer to a nested field, including arrays. This means
+  that field names containing a period (".") are not supported.
+
+  {{% notice info %}}
+  The sources referred to in `InfoMetadata` should only return a
+  single row. If more rows are returned, only the first is used.
+  {{% /notice %}}
+
+  ## See also
+
+  - [`Server.Monitor.StoreClientHWInfo`](/exchange/artifacts/pages/server.monitor.storeclienthwinfo/):
+    sibling artifact tailored for hardware identification (extracting
+    serial number as primary purpose)
+  - [How can I automatically add & update client metadata?](/knowledge_base/tips/automating_metadata/):
+    in-depth walkthrough about how to save interrogation data as
+    client metadata
+
+  #metadata #automation
 
 type: SERVER_EVENT
 

--- a/content/knowledge_base/tips/automating_metadata.md
+++ b/content/knowledge_base/tips/automating_metadata.md
@@ -132,7 +132,7 @@ expected results:
 ![Linux BIOS info](biosinfo_linux.png)
 
 The exchange artifact
-[Generic.Client.HW.Identification](/exchange/artifacts/pages/generic.client.hw.identification/)
+[`Generic.Client.HW.Identification`](/exchange/artifacts/pages/generic.client.hw.identification/)
 can be used to extract hardware information like
 `Generic.Client.BiosInfo` and more, with support for all three
 operating systems.

--- a/content/knowledge_base/tips/automating_metadata.md
+++ b/content/knowledge_base/tips/automating_metadata.md
@@ -131,6 +131,11 @@ expected results:
 
 ![Linux BIOS info](biosinfo_linux.png)
 
+The exchange artifact
+[Generic.Client.HW.Identification](/exchange/artifacts/pages/generic.client.hw.identification/)
+can be used to extract hardware information like
+`Generic.Client.BiosInfo` and more, with support for all three
+operating systems.
 
 #### Add an artifact to collect the last logged on user
 
@@ -274,6 +279,18 @@ At this point we have configured the collection of the required data. The next
 step is to create a server event artifact and add it to server monitoring. This
 will monitor for incoming results and then populate the metadata fields with
 data from these results.
+
+{{% notice info %}}
+You do not have to create your own monitoring artifacts. There are two
+artifacts in the [exchange](/exchange/) that will likely cover most of
+your needs:
+
+- [`Server.Monitor.StoreClientHWInfo`](/exchange/artifacts/pages/server.monitor.storeclienthwinfo/):
+  Store hardware information, with special logic to pick a suitable computer serial
+- [`Server.Monitor.StoreClientInfo`](/exchange/artifacts/pages/server.monitor.storeclientinfo/):
+  Store any kind of interrogation data as client metadata.
+
+{{% /notice %}}
 
 #### Add a Server Event Monitoring artifact
 
@@ -444,4 +461,4 @@ WHERE LastUser = "Mary"
 
 ![Running a search in a notebook](vql_search.png)
 
-Tags: #configuration #vql #deployment
+Tags: #configuration #vql #deployment #automation #metadata


### PR DESCRIPTION
# Client metadata and asset management

Although I imagine everyone using Velociraptor mostly to fetch data en masse using hunts, personally I usually look up individual clients for investigations. Later on I will run targeted hunts based on metadata/tags, and rarely hunt across the whole fleet.

One of the perhaps biggest upgrades for myself has been to be able to look up clients based on their serial number or assigned owner (fetched from an asset management system). I have since extended this system to tie the client to external systems and agents like Defender/Intune/Entra and Action1/NinjaOne based on its serial or agent ID.

I have used most of these artifacts for years now, but I have not had the capacity to document how to use them. predictible has since written a good [knowledge base artifact](https://docs.velociraptor.app/knowledge_base/tips/automating_metadata/) that covers most if not all the concepts, so releasing the following artifacts may not require a lot of additional documentation. There should be at least a complete example showing

- How to extend Custom.Generic.Client.Info with Generic.Client.HW.Identification
- Configure Server.Monitor.StoreClientHWInfo (illustrate how to use SerialColumn and HWInfoMetadata)
- Configure Server.Monitor.StoreClientInfo (illustrate how to use InfoMetadata)

An excellent showcase would use Defender, ADStatus FIXME for more useful fields.

Perhaps a knowledge base article or blog post (whichever is the most suitable format) referring to predictible's existing article, then simply setting up all artifacts and showing how to look up various indexed metadata provided by these new artifacts is enough?

## Client artifacts

Gather information from the client system.

These are helper artifacts fetching information about the client. The aim is to extract some sort of identifier, a computer serial or some sort of ID, that will later be used to fetch a lot of telemetry from the computer from another agent. – Rather than implementing all of that in Veloriraptor. However, when the useful data is already there as part of fetching this identifier, it will be included in the artifact.

The intended way to use of these artifacts is by calling them from Custom.Generic.Client.Info, but they may be used on their own.

## Generic.Client.HW.Identification

This artifact fetches useful hardware identification values from all OSes and has served me well for years. It would be nice to gather experience from manufacturers that I have never run clients on. The only changes it has seen recently is a very rudimentary attempt to detect whether the client is running in a VM.

## Generic.Client.ADStatus

The primary use case for this artifact is to get a simple answer to whether the computer is joined to an Active Directory domain or not. Depending on the OS, a lot more details are provided.

## Generic.Client.Defender.Health

The primary use case for this artifact is to get the MDATP machine ID for all three OSes, but an extensive list of health data from the agent is fetched.

## TODO: A good fourth example

I have some ideas, but I am very open for suggestions that goes beyond just my own particular needs.

## Server event artifacts

Store information from interrogation as client metadata.

Storing data from the Custom.Generic.Client.Info is easy and almost does not require its own published artifact. However, the following two artifacts saves the user from having to write this themselves, and lets them configure their desired result from parameters.

### Server.Monitor.StoreClientHWInfo

This is a relatively simple artifact, but it is very useful. The parameter SerialColumn lets you choose which metadata columns (defaults assuming Generic.Client.HW.Identification is used) to use for serial value, in a prioritised order. The artifact comes with common patterns to ignore. It could be extended with some transforms for manufacturers who store serials in a weird way.

### Server.Monitor.StoreClientInfo

Given a specified interrogation artifact, this artifacts stores specified columns from specified sources as optionally renamed metadata values. Sources should only contain one row, but if they contain more, the first row is picked.

Example use of the InfoMetadata parameter:

| Source           | Field                                  | Alias       |
|------------------|----------------------------------------|-------------|
| BasicInformation | OS                                     | os          |
| BasicInformation | Architecture                           | arch        |
| ADStatus         | DomainJoined                           | ad_joined   |
| MDATPHealth      | MDATPHealth.edrMachineId               | defender_id |
| ComputerSetup    | Details.computer setup.execution.timestamp | cs_executed |
| ComputerSetup    | Details.computer setup.git.hash        | cs_version  |

(The ComputerSetup source here is an artifact fetching metadata produced by an ansible playbook run, telling us when it was last executed, and what version.)

This artifact could probably be over-engineered to add some sort of transformation logic to support multiple rows. However, I think it is fine as it is.

I am not sure if it is fixed, but attempting to store empty metadata created issues in some version, hence the conditional at the end.

# Asset management

Now that clients have various IDs set in metadata, it would be great to pull useful data (not stored on the endpoint) from external sources using APIs. Examples:

- Fetch assigned owner and assigned use from an asset management system
- Look up account name / account ID
- Fetch vulnerabilities and security issues/recommendations
- TODO: plenty of examples to fill

Use cases where this additional information is fetched and then used in a notebook are topics for a chapter of its own. Right now we want to fetch data to store as additional indexed metadata. We will use one particular example: Fetching information about the assigned owner from an asset management system.

Velociraptor will give us plenty of information about logged-in users, but I want to know who actually owns the computer. This can then be used to determine whether the last-logged in user shouldn't even be logged into the system in the first place. Other information, like assigned department, location, or other useful custom fields, could also be valuable.

We will use Snipe-IT as our example asset management system. It is most likely not used in large enterprises, but is open-source and although a bit cumbersome, still powerful and useful. I have been planning to write one for Atlassian Assets. The system in question matters little, since they will have have some sort of REST API and very common concepts.

We want to do the following:

- Fetch assets (perhaps matching certain filters)
- Match assets by serial
- Transform some of the information
- Synchronise selected data from the asset and save as client metadata

We want this data updated, so the data will be synchronised either

- On demand (running the server artifact)
- Whenever the client is interrogated, giving us immediate updates for new clients (done by a server event artifact)
- Periodically, so that changes in the assets are updated (e.g. new owner) (done by a server event artifact)

The server event artifacts simply call the server artifacts. Since the server artifact has a lot of important parameters, and since we cannot expect the administrator to have to fill these in in three separate places, the following is done:

- The server artifact saves its arguments to a server metadata value
- The event artifacts fetches all arguments from the same value

This may be elegant or ugly, depending on who you ask, but it works and certainly beats the alternative.

## Server artifacts

### Server.Assets.SnipeIT.Sync

Querying Snipe-IT is trivial (at least with the QueryAPI server artifact helper). However, in order to create a user-friendly way to select which fields to synchronise, with support for custom fields and aliases, additional logic is needed. The artifact may be used in three ways:

- Simply fetch all assets (matching filters)
- Fetch assets with a serial found in Velociraptor clients
- Synchronise client metadata

The first two are "read-only" actions and can be used with notebook suggestions to

- Find clients missing serial numbers
- Find clients not in assets
- Find assets not running Velociraptor

## Server event artifacts

### Server.Monitor.SnipeIT.Sync.Interrogation

Update client metadata whenever it is interrogated. Shows what metadata changed (from/to).

## Server.Monitor.SnipeIT.Sync.Periodic

Update client metadata at a specified interval. Shows what metadata changed (from/to).

# Artifact table

Complete artifact list (with dependencies, if any):

| Name | Type | Deps. | Description |
|------|------|--------|-------------|
| Generic.Client.HW.Identification | Client | - | Pull hardware identification information from the system, like serial number and computer model |
| Generic.Client.ADStatus | Client | - | Fetch Active Directory status |
| Generic.Client.Defender.Health | Client | - | Get Microsoft Defender health status |
| Server.Monitor.StoreClientHWInfo | Server | - | Store client HW info as metadata |
| Server.Monitor.StoreClientInfo | Server | (HW.Identification) | Store client info as metadata |
| Server.Utils.QueryAPI | Server | - | Query an HTTP API with login and pagination support |
| Server.Assets.SnipeIT.Sync | Server | (QueryAPI) | Save key Snipe-IT asset information as client metadata |
| Server.Monitor.SnipeIT.Sync.Interrogation | Server event | SnipeIT.Sync | Update asset information when client is interrogated |
| Server.Monitor.SnipeIT.Sync.Periodic | Server event | SnipeIT.Sync | Update asset information regularly at a specified interval |