### PR TITLE
Scroll current menu item into top of menu bar

### DIFF
--- a/assets/js/menu-tml.js
+++ b/assets/js/menu-tml.js
@@ -75,7 +75,7 @@ function addToNode(dom, nodes) {
           {{- template "section-tree-nav-json" dict "sect" . -}}
         {{- end -}}
        {{- end -}}
-     ], "no_children": "{{.Params.no_children | html }}"},
+     ]},
    {{- else -}}
     {{- if not (or .Params.Hidden .Params.no_menu) -}}
       {"link": "{{.RelPermalink}}", "title": "{{.Params.Pre | html}}{{.LinkTitle | html }}{{.Params.Post | html}}"},

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -119,4 +119,11 @@
   // Only show it once the menu is stable - this avoids unintended flickering
   menu.removeClass("hidden");
 
+  // Scroll the highlighted element into view
+  $(window).on('load', function(){
+      $("li.dd-item.active")[0].scrollIntoView();
+  })
+
+  menu.find("li.dd-item.active")[0].scrollIntoView();
+
 </script>

--- a/static/css/theme-mine.css
+++ b/static/css/theme-mine.css
@@ -1145,3 +1145,15 @@ table tr th {
 .sidemenu.hidden {
     display: none;
 }
+
+li.dd-item {
+    width: max-content;
+}
+
+body #sidebar ul li li {
+    overflow: hidden;
+}
+
+ul.sidebar {
+    width: max-content;
+}


### PR DESCRIPTION
This helps when looking at pages further down to nav pane since the active tree node is always visible.