### PR TITLE
Use latest release when verifying artifacts

### DIFF
--- a/scripts/exchange_verify.py
+++ b/scripts/exchange_verify.py
@@ -27,7 +27,7 @@ Datastore:
 VELO_CONFIG_FILENAME = "/tmp/velo.config.yaml"
 
 VELO_FILENAME = "/tmp/velociraptor"
-VELO_URL = "https://github.com/Velocidex/velociraptor/releases/download/v0.74/velociraptor-v0.74.3-linux-amd64-musl"
+VELO_URL = "https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.1-linux-amd64-musl"
 EXCHANGE_PATH = os.path.abspath("./content/exchange/artifacts/")
 VELO_LOGFILE = "/tmp/velo.log"
 


### PR DESCRIPTION
Otherwise the verification job fails for VQL using the new default arguments feature of the language.

Closes #1224.