### PR TITLE
Update Linux.Detection.Honeyfiles.yaml

### DIFF
--- a/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
+++ b/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
@@ -45,6 +45,8 @@ sources:
         SELECT OS From info() where OS = 'linux' AND version(plugin="watch_ebpf") >= 2
 
     query: |
+      LET ComputerName <= dict(H={ SELECT Hostname FROM info() }).H[0].Hostname
+      
       // Get detailed process information
       LET GetProcInfo(EventData, Tracker, pTracker, System) =
           dict(Image=Tracker.Data.Exe || EventData.cmdpath ||
@@ -53,6 +55,7 @@ sources:
                CommandLine=Tracker.Data.CommandLine,
                ParentImage=pTracker.Data.Exe,
                ParentCommandLine=pTracker.Data.CommandLine,
+               Username=Tracker.Data.Username,
                CreateTime=timestamp(epoch=EventData.ctime) ||
                  System.ThreadStartTime,
                CallChain=join(array=process_tracker_callchain(
@@ -158,17 +161,20 @@ sources:
       
       LET Track = SELECT Timestamp,
                          EventData.pathname AS FileName,
+                         GetProcInfo(EventData=EventData,
+                                     Tracker=process_tracker_get(
+                                       id=System.HostProcessID),
+                                     pTracker=process_tracker_get(
+                                       id=System.HostParentProcessID),
+                                     System=System) AS ProcInfo,
                          *,
                          (System.HostProcessID + EventData.pathname) AS DedupKey
-        FROM delay(query=AuditEvents, delay=30)
+        FROM delay(query=AuditEvents, delay=3)
       
       SELECT Timestamp,
+             ComputerName,
              System.HostProcessID AS Pid,
              FileName,
-             GetProcInfo(
-               EventData=EventData,
-               Tracker=process_tracker_get(id=System.HostProcessID),
-               pTracker=process_tracker_get(id=System.HostParentProcessID),
-               System=System) AS ProcInfo
-      FROM dedup(query=Track, key="DedupKey", timeout=30)
+             ProcInfo
+      FROM dedup(query=Track, key="DedupKey", timeout=10)
       WHERE NOT ProcInfo.Image =~ ProcessExceptionsRegex

--- a/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
+++ b/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
@@ -45,6 +45,21 @@ sources:
         SELECT OS From info() where OS = 'linux' AND version(plugin="watch_ebpf") >= 2
 
     query: |
+      // Get detailed process information
+      LET GetProcInfo(EventData, Tracker, pTracker, System) =
+          dict(Image=Tracker.Data.Exe || EventData.cmdpath ||
+                 System.ProcessName,
+               ImageName=System.ProcessName,
+               CommandLine=Tracker.Data.CommandLine,
+               ParentImage=pTracker.Data.Exe,
+               ParentCommandLine=pTracker.Data.CommandLine,
+               CreateTime=timestamp(epoch=EventData.ctime) ||
+                 System.ThreadStartTime,
+               CallChain=join(array=process_tracker_callchain(
+                                id=System.HostProcessID).Data.Name,
+                              sep="->"),
+               TrackerHit=if(condition=Tracker != NULL, then=true, else=false))
+      
       LET RandomChars(size) = SELECT
           format(format="%02x", args=rand(range=256)) AS HexByte
         FROM range(end=size)
@@ -70,13 +85,10 @@ sources:
                                     len(list=unhex(string=MagicBytes)) - 7 AS _PaddingSize
         FROM Honeyfiles
       
-      LET target_users = SELECT User,
-                                Homedir,
-                                Uid
-        FROM Artifact.Linux.Sys.Users()
-        WHERE int(int=Uid) >= 1000
-         AND NOT Homedir = '/nonexistent'
-              AND User =~ HoneyUserRegex
+      LET target_users = SELECT Name AS User,
+                                OSPath AS Homedir
+        FROM glob(globs="/home/*")
+        WHERE User =~ HoneyUserRegex
       
       LET show_honeyfiles = SELECT TargetPath,
                                    Enabled,
@@ -133,12 +145,10 @@ sources:
       
       LET CurrentPid <= getpid()
       
-      // Exclude containers by checking process id.
       LET TargetEvents = SELECT *
         FROM watch_ebpf(events=["security_file_open"], policy=Policy)
         WHERE System.EventName = "security_file_open"
-         AND System.ProcessID != CurrentPid
-              AND System.HostProcessID = System.ProcessID
+         AND System.HostProcessID != CurrentPid
       
       LET AuditEvents = SELECT
           *, timestamp(string=System.Timestamp) AS Timestamp,
@@ -146,25 +156,19 @@ sources:
         FROM TargetEvents
         WHERE IsHoneyFile != NULL
       
-      LET Track = SELECT
-          Timestamp,
-          System.ProcessID AS Pid,
-          EventData.pathname AS FileName,
-          process_tracker_get(id=System.ProcessID).Data AS ProcInfo,
-          join(array=process_tracker_callchain(id=System.ProcessID).Data.Name,
-               sep="->") AS CallChain,
-          (System.ProcessID + EventData.pathname) AS DedupKey
-        FROM AuditEvents
-        WHERE NOT ProcInfo.Exe =~ ProcessExceptionsRegex
+      LET Track = SELECT Timestamp,
+                         EventData.pathname AS FileName,
+                         *,
+                         (System.HostProcessID + EventData.pathname) AS DedupKey
+        FROM delay(query=AuditEvents, delay=30)
       
       SELECT Timestamp,
-             Pid,
+             System.HostProcessID AS Pid,
              FileName,
-             ProcInfo,
-             CallChain
-      FROM dedup(query={
-          SELECT *
-          FROM delay(query=Track, delay=5)
-        },
-                 key="DedupKey",
-                 timeout=2)
+             GetProcInfo(
+               EventData=EventData,
+               Tracker=process_tracker_get(id=System.HostProcessID),
+               pTracker=process_tracker_get(id=System.HostParentProcessID),
+               System=System) AS ProcInfo
+      FROM dedup(query=Track, key="DedupKey", timeout=30)
+      WHERE NOT ProcInfo.Image =~ ProcessExceptionsRegex

--- a/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
+++ b/content/exchange/artifacts/Linux.Detection.Honeyfiles.yaml
@@ -28,9 +28,21 @@ parameters:
      description: User name regex that will be used to host honeyfiles.
      type: string
      default: "."
+   - name: Policy
+     description: Tracee Policy
+     default: |
+       metadata:
+         name: file-open-home
+       spec:
+          scope:
+            - global
+          rules:
+            - event: security_file_open
+              filters:
+                - args.pathname=/home/*
 sources:
   - precondition:
-        SELECT OS From info() where OS = 'linux' AND version(plugin="watch_ebpf") >= 0
+        SELECT OS From info() where OS = 'linux' AND version(plugin="watch_ebpf") >= 2
 
     query: |
       LET RandomChars(size) = SELECT
@@ -83,6 +95,8 @@ sources:
                  AND copy(dest=TargetPath,
                           create_directories='y',
                           accessor='data',
+                          permissions="0644",
+                          dir_permissions="0755",
                           filename=unhex(
                             string=MagicBytes + join(
                               array=RandomChars(size=_PaddingSize).HexByte) +
@@ -108,32 +122,20 @@ sources:
           check_exist(path=TargetPath)[0].IsHoneyFile AS IsHoneyFile
         FROM copy_honeyfiles
       
-      LET chmod_honeyfiles = SELECT *
-        FROM foreach(row=add_honeyfiles,
-                     query={
-          SELECT TargetPath,
-                 Enabled,
-                 MagicBytes,
-                 MinSize,
-                 MaxSize,
-                 Size,
-                 IsHoneyFile
-          FROM execve(argv=["chmod", "+r", TargetPath])
-        })
-      
       LET _ <= atexit(query={ SELECT * FROM remove_honeyfiles })
       
       LET WatchFiles <= to_dict(item={
           SELECT TargetPath AS _key,
                  IsHoneyFile AS _value
-          FROM chmod_honeyfiles
+          FROM add_honeyfiles
           WHERE IsHoneyFile
         })
       
       LET CurrentPid <= getpid()
       
+      // Exclude containers by checking process id.
       LET TargetEvents = SELECT *
-        FROM watch_ebpf(events=["security_file_open"])
+        FROM watch_ebpf(events=["security_file_open"], policy=Policy)
         WHERE System.EventName = "security_file_open"
          AND System.ProcessID != CurrentPid
               AND System.HostProcessID = System.ProcessID


### PR DESCRIPTION
This update to honeyfiles uses the new Tracee policy for much better performance, as well as the new copy() permissions and dir_permissions, making honeyfiles on Linux fully functional.