### PR TITLE
Add Windows Wazuh agent install artifact

### DIFF
--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -1,0 +1,459 @@
+name: Windows.Install.Wazuh.Agent
+description: |
+  Installs the Wazuh Windows agent and configures it to use the supplied
+  Wazuh manager IP address or hostname.
+
+  By default this artifact asks the GitHub releases API for the latest Wazuh
+  release. If that release exposes a Windows MSI asset, the artifact downloads
+  it directly. If not, it derives the official Wazuh packages URL from the
+  latest GitHub tag. Set WazuhVersion to pin to a manager-compatible agent
+  version, or set MsiUrl when you need to override the MSI download URL.
+
+  NOTE: Requires administrative privileges on the endpoint.
+
+author: Julian Hill - @julianghill
+type: CLIENT
+
+required_permissions:
+  - EXECVE
+  - FILESYSTEM_WRITE
+
+precondition: SELECT OS From info() where OS = 'windows'
+
+parameters:
+  - name: ManagerIP
+    description: Wazuh manager IP address or hostname. This is required.
+    default: ""
+  - name: RegistrationServer
+    description: Optional Wazuh registration server. If empty, the first ManagerIP address is used.
+    default: ""
+  - name: RegistrationPassword
+    description: Optional Wazuh enrollment password. If empty, WAZUH_REGISTRATION_PASSWORD is not passed to the installer.
+    default: ""
+  - name: AgentName
+    description: Optional Wazuh agent name. If empty, Wazuh uses its default agent naming behavior.
+    default: ""
+  - name: AgentGroup
+    description: Optional Wazuh agent group or comma-separated groups.
+    default: ""
+  - name: MsiUrl
+    description: Optional MSI URL override. If set, this takes precedence over WazuhVersion.
+    default: ""
+  - name: WazuhVersion
+    description: Optional Wazuh agent version to install, without the package release suffix. If empty, the artifact resolves the latest Wazuh release.
+    default: ""
+  - name: ExpectedSha256
+    description: Optional SHA256 expected hash for the downloaded MSI.
+    default: ""
+  - name: GithubReleaseApiUrl
+    description: GitHub API URL used to resolve the latest Wazuh release.
+    default: https://api.github.com/repos/wazuh/wazuh/releases/latest
+  - name: UpdateExistingConfig
+    type: bool
+    description: Update ossec.conf with ManagerIP after installation when possible. Supports comma-separated managers.
+    default: N
+  - name: WazuhConfigPath
+    description: Path to the Wazuh agent ossec.conf file.
+    default: C:\Program Files (x86)\ossec-agent\ossec.conf
+  - name: StartService
+    type: bool
+    description: Start or restart WazuhSvc after installation and configuration.
+    default: Y
+  - name: UploadInstallLog
+    type: bool
+    description: Upload the msiexec install log.
+    default: Y
+  - name: DownloadTimeoutSec
+    type: int
+    description: Download timeout in seconds.
+    default: 300
+
+sources:
+  - name: Install
+    query: |
+      LET TempDir <= tempdir()
+      LET MsiPath <= TempDir + "\\wazuh-agent.msi"
+      LET LogPath <= TempDir + "\\wazuh-agent-install.log"
+
+      LET EnvVars <= dict(
+        WAZUH_MANAGER=ManagerIP,
+        WAZUH_REGISTRATION_SERVER=RegistrationServer,
+        WAZUH_REGISTRATION_PASSWORD=RegistrationPassword,
+        WAZUH_AGENT_NAME=AgentName,
+        WAZUH_AGENT_GROUP=AgentGroup,
+        WAZUH_MSI_URL=MsiUrl,
+        WAZUH_VERSION=WazuhVersion,
+        WAZUH_EXPECTED_SHA256=ExpectedSha256,
+        WAZUH_GITHUB_RELEASE_API=GithubReleaseApiUrl,
+        WAZUH_UPDATE_EXISTING_CONFIG=if(condition=UpdateExistingConfig, then="true", else="false"),
+        WAZUH_CONFIG_PATH=WazuhConfigPath,
+        WAZUH_START_SERVICE=if(condition=StartService, then="true", else="false"),
+        WAZUH_DOWNLOAD_TIMEOUT_SEC=str(str=DownloadTimeoutSec),
+        WAZUH_MSI_PATH=MsiPath,
+        WAZUH_INSTALL_LOG=LogPath,
+        TEMP=TempDir,
+        TMP=TempDir
+      )
+
+      LET PowershellScript = '''
+      $ErrorActionPreference = "Stop"
+      $ProgressPreference = "SilentlyContinue"
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+      function Assert-RequiredValue {
+        param(
+          [string] $Name,
+          [string] $Value
+        )
+
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+          throw "$Name is required."
+        }
+      }
+
+      function Assert-SafeArgument {
+        param(
+          [string] $Name,
+          [string] $Value,
+          [bool] $Required = $false
+        )
+
+        if ($Required) {
+          Assert-RequiredValue -Name $Name -Value $Value
+        }
+
+        if (-not [string]::IsNullOrEmpty($Value) -and $Value -match "[`r`n`"]") {
+          throw "$Name contains an unsupported character."
+        }
+      }
+
+      function Quote-ProcessArgument {
+        param([string] $Value)
+
+        '"' + ($Value -replace '"', '\"') + '"'
+      }
+
+      function New-MsiPropertyArgument {
+        param(
+          [string] $Name,
+          [string] $Value
+        )
+
+        $Name + "=" + (Quote-ProcessArgument -Value $Value)
+      }
+
+      function Get-WazuhMsiUrlFromVersion {
+        param([string] $Version)
+
+        $normalizedVersion = $Version -replace "^v", ""
+        if ($normalizedVersion -notmatch "^\d+\.\d+\.\d+$") {
+          throw "WazuhVersion '$Version' must be a semantic version such as 4.x.y. Set MsiUrl explicitly for other package names."
+        }
+
+        $major = $normalizedVersion.Split(".")[0]
+        [pscustomobject]@{
+          Version = $normalizedVersion
+          Url = "https://packages.wazuh.com/$major.x/windows/wazuh-agent-$normalizedVersion-1.msi"
+        }
+      }
+
+      function Get-CommaSeparatedValues {
+        param(
+          [string] $Name,
+          [string] $Value
+        )
+
+        $values = @($Value -split "," |
+          ForEach-Object { $_.Trim() } |
+          Where-Object { $_.Length -gt 0 })
+
+        if ($values.Count -eq 0) {
+          throw "$Name did not contain a usable value."
+        }
+
+        $values
+      }
+
+      function Get-ManagerAddresses {
+        param([string] $ManagerList)
+
+        $addresses = @(Get-CommaSeparatedValues -Name "ManagerIP" -Value $ManagerList)
+        if ($addresses.Count -eq 0) {
+          throw "ManagerIP did not contain a usable manager address."
+        }
+
+        $addresses
+      }
+
+      $manager = $env:WAZUH_MANAGER
+      $registrationServer = $env:WAZUH_REGISTRATION_SERVER
+      $registrationPassword = $env:WAZUH_REGISTRATION_PASSWORD
+      $agentName = $env:WAZUH_AGENT_NAME
+      $agentGroup = $env:WAZUH_AGENT_GROUP
+      $manualMsiUrl = $env:WAZUH_MSI_URL
+      $requestedVersion = $env:WAZUH_VERSION
+      $githubReleaseApi = $env:WAZUH_GITHUB_RELEASE_API
+      $expectedSha256 = $env:WAZUH_EXPECTED_SHA256
+      $msiPath = $env:WAZUH_MSI_PATH
+      $installLog = $env:WAZUH_INSTALL_LOG
+      $downloadTimeoutSec = [int]$env:WAZUH_DOWNLOAD_TIMEOUT_SEC
+      $configPath = $env:WAZUH_CONFIG_PATH
+      $updateExistingConfig = $env:WAZUH_UPDATE_EXISTING_CONFIG -eq "true"
+      $startService = $env:WAZUH_START_SERVICE -eq "true"
+
+      Assert-SafeArgument -Name "ManagerIP" -Value $manager -Required $true
+      Assert-SafeArgument -Name "RegistrationServer" -Value $registrationServer
+      Assert-SafeArgument -Name "RegistrationPassword" -Value $registrationPassword
+      Assert-SafeArgument -Name "AgentName" -Value $agentName
+      Assert-SafeArgument -Name "AgentGroup" -Value $agentGroup
+      Assert-SafeArgument -Name "MsiUrl" -Value $manualMsiUrl
+      Assert-SafeArgument -Name "WazuhVersion" -Value $requestedVersion
+      Assert-SafeArgument -Name "ExpectedSha256" -Value $expectedSha256
+      Assert-SafeArgument -Name "GithubReleaseApiUrl" -Value $githubReleaseApi -Required $true
+      Assert-SafeArgument -Name "WazuhConfigPath" -Value $configPath -Required $true
+
+      $managerAddresses = @(Get-ManagerAddresses -ManagerList $manager)
+      $manager = $managerAddresses -join ","
+
+      if ([string]::IsNullOrWhiteSpace($registrationServer)) {
+        $registrationServer = $managerAddresses[0]
+      } else {
+        $registrationServerAddresses = @(Get-CommaSeparatedValues -Name "RegistrationServer" -Value $registrationServer)
+        if ($registrationServerAddresses.Count -gt 1) {
+          throw "RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses."
+        }
+
+        $registrationServer = $registrationServerAddresses[0]
+      }
+
+      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
+        $agentGroup = (@(Get-CommaSeparatedValues -Name "AgentGroup" -Value $agentGroup) -join ",")
+      }
+
+      $releaseTag = $null
+      $resolvedVersion = $null
+      $downloadSource = "manual"
+      $downloadUrl = $manualMsiUrl
+
+      if ([string]::IsNullOrWhiteSpace($downloadUrl)) {
+        if (-not [string]::IsNullOrWhiteSpace($requestedVersion)) {
+          $versionDetails = Get-WazuhMsiUrlFromVersion -Version $requestedVersion
+          $resolvedVersion = $versionDetails.Version
+          $downloadUrl = $versionDetails.Url
+          $downloadSource = "packages_wazuh_from_version"
+        } else {
+          $release = Invoke-RestMethod `
+            -Uri $githubReleaseApi `
+            -Headers @{ "User-Agent" = "Velociraptor-Wazuh-Installer" } `
+            -TimeoutSec $downloadTimeoutSec
+
+          $releaseTag = [string]$release.tag_name
+          Assert-RequiredValue -Name "GitHub release tag" -Value $releaseTag
+
+          $asset = @($release.assets) |
+            Where-Object { $_.name -match "^wazuh-agent-.+-1\.msi$" } |
+            Select-Object -First 1
+
+          if ($asset) {
+            $downloadUrl = [string]$asset.browser_download_url
+            $downloadSource = "github_release_asset"
+          } else {
+            $versionDetails = Get-WazuhMsiUrlFromVersion -Version $releaseTag
+            $resolvedVersion = $versionDetails.Version
+            $downloadUrl = $versionDetails.Url
+            $downloadSource = "packages_wazuh_from_github_tag"
+          }
+
+        }
+      }
+
+      Assert-RequiredValue -Name "MSI download URL" -Value $downloadUrl
+
+      $parent = Split-Path -Parent $msiPath
+      if (-not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+      }
+
+      Invoke-WebRequest `
+        -Uri $downloadUrl `
+        -OutFile $msiPath `
+        -UseBasicParsing `
+        -TimeoutSec $downloadTimeoutSec
+
+      $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msiPath).Hash.ToLowerInvariant()
+      if (-not [string]::IsNullOrWhiteSpace($expectedSha256) -and
+          $actualSha256 -ne $expectedSha256.ToLowerInvariant()) {
+        throw "Downloaded MSI SHA256 '$actualSha256' did not match ExpectedSha256 '$expectedSha256'."
+      }
+
+      $msiArguments = @(
+        "/i",
+        (Quote-ProcessArgument -Value $msiPath),
+        "/qn",
+        "/norestart",
+        "/l*v",
+        (Quote-ProcessArgument -Value $installLog),
+        (New-MsiPropertyArgument -Name "WAZUH_MANAGER" -Value $manager),
+        (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_SERVER" -Value $registrationServer)
+      )
+
+      if (-not [string]::IsNullOrWhiteSpace($registrationPassword)) {
+        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_PASSWORD" -Value $registrationPassword)
+      }
+
+      if (-not [string]::IsNullOrWhiteSpace($agentName)) {
+        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_NAME" -Value $agentName)
+      }
+
+      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
+        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_GROUP" -Value $agentGroup)
+      }
+
+      $process = Start-Process `
+        -FilePath "msiexec.exe" `
+        -ArgumentList $msiArguments `
+        -Wait `
+        -PassThru
+
+      if ($process.ExitCode -ne 0) {
+        throw "msiexec.exe failed with exit code $($process.ExitCode)."
+      }
+
+      $configUpdated = $false
+      $configUpdateStatus = "not_requested"
+      if ($updateExistingConfig -and (Test-Path -LiteralPath $configPath)) {
+        [xml]$config = Get-Content -LiteralPath $configPath
+        $root = $config.SelectSingleNode("/ossec_config")
+        if ($null -eq $root) {
+          throw "Unable to update '$configPath': missing /ossec_config root element."
+        }
+
+        $client = $config.SelectSingleNode("/ossec_config/client")
+        if ($null -eq $client) {
+          $client = $config.CreateElement("client")
+          [void]$root.AppendChild($client)
+          $configUpdated = $true
+        }
+
+        $servers = @($client.SelectNodes("server"))
+        if ($servers.Count -eq 0) {
+          $server = $config.CreateElement("server")
+          [void]$client.AppendChild($server)
+          $servers = @($server)
+          $configUpdated = $true
+        }
+
+        $template = $servers[0]
+        for ($i = 0; $i -lt $managerAddresses.Count; $i++) {
+          if ($i -lt $servers.Count) {
+            $server = $servers[$i]
+          } else {
+            $server = $template.CloneNode($true)
+            [void]$client.AppendChild($server)
+            $configUpdated = $true
+          }
+
+          $address = $server.SelectSingleNode("address")
+          if ($null -eq $address) {
+            $address = $config.CreateElement("address")
+            if ($server.HasChildNodes) {
+              [void]$server.InsertBefore($address, $server.FirstChild)
+            } else {
+              [void]$server.AppendChild($address)
+            }
+            $configUpdated = $true
+          }
+
+          if ($address.InnerText -ne $managerAddresses[$i]) {
+            $address.InnerText = $managerAddresses[$i]
+            $configUpdated = $true
+          }
+        }
+
+        if ($servers.Count -gt $managerAddresses.Count) {
+          for ($i = $servers.Count - 1; $i -ge $managerAddresses.Count; $i--) {
+            [void]$client.RemoveChild($servers[$i])
+            $configUpdated = $true
+          }
+        }
+
+        if ($configUpdated) {
+          $config.Save($configPath)
+          $configUpdateStatus = "updated"
+        } else {
+          $configUpdateStatus = "already_current"
+        }
+      } elseif ($updateExistingConfig) {
+        $configUpdateStatus = "missing_config"
+      }
+
+      $serviceStatus = "not_requested"
+      if ($startService) {
+        $service = Get-Service -Name "WazuhSvc" -ErrorAction Stop
+        if ($service.Status -eq "Running") {
+          Restart-Service -Name "WazuhSvc" -Force -ErrorAction Stop
+        } else {
+          Start-Service -Name "WazuhSvc" -ErrorAction Stop
+        }
+
+        $serviceStatus = (Get-Service -Name "WazuhSvc" -ErrorAction Stop).Status.ToString()
+      }
+
+      [ordered]@{
+        Status = "Installed"
+        ManagerIP = $manager
+        RegistrationServer = $registrationServer
+        RegistrationPasswordSupplied = -not [string]::IsNullOrWhiteSpace($registrationPassword)
+        AgentName = $agentName
+        AgentGroup = $agentGroup
+        RequestedVersion = $requestedVersion
+        ResolvedVersion = $resolvedVersion
+        ReleaseTag = $releaseTag
+        DownloadSource = $downloadSource
+        MsiUrl = $downloadUrl
+        MsiPath = $msiPath
+        MsiSha256 = $actualSha256
+        MsiExitCode = $process.ExitCode
+        ConfigPath = $configPath
+        ConfigUpdated = $configUpdated
+        ConfigUpdateStatus = $configUpdateStatus
+        ServiceStatus = $serviceStatus
+        InstallLog = $installLog
+      } | ConvertTo-Json -Compress
+      '''
+
+      LET Run <= SELECT Stdout, Stderr, ReturnCode, Complete
+      FROM execve(
+        argv=[
+          "powershell.exe",
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy", "Bypass",
+          "-Command", PowershellScript
+        ],
+        env=EnvVars,
+        length=1000000
+      )
+
+      LET LogUpload <= SELECT upload(file=OSPath) AS Upload
+      FROM glob(globs=LogPath)
+      WHERE UploadInstallLog
+
+      SELECT Stdout, Stderr, ReturnCode, Complete,
+        LogUpload.Upload[0] AS InstallLog,
+        dict(
+          ManagerIP=ManagerIP,
+          RegistrationServer=RegistrationServer,
+          RegistrationPasswordSupplied=if(condition=RegistrationPassword, then=true, else=false),
+          AgentName=AgentName,
+          AgentGroup=AgentGroup,
+          MsiUrl=MsiUrl,
+          WazuhVersion=WazuhVersion,
+          GithubReleaseApiUrl=GithubReleaseApiUrl,
+          ExpectedSha256=ExpectedSha256,
+          UpdateExistingConfig=UpdateExistingConfig,
+          WazuhConfigPath=WazuhConfigPath,
+          StartService=StartService,
+          DownloadTimeoutSec=DownloadTimeoutSec
+        ) AS RequestedSettings
+      FROM Run

--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -3,19 +3,23 @@ description: |
   Installs the Wazuh Windows agent and configures it to use the supplied
   Wazuh manager IP address or hostname.
 
-  By default this artifact asks the GitHub releases API for the latest Wazuh
-  release. If that release exposes a Windows MSI asset, the artifact downloads
-  it directly. If not, it derives the official Wazuh packages URL from the
-  latest GitHub tag. Set WazuhVersion to pin to a manager-compatible agent
-  version, or set MsiUrl when you need to override the MSI download URL.
-
-  NOTE: Requires administrative privileges on the endpoint.
+  By default this artifact downloads the Wazuh agent MSI listed below and uses
+  it for installation. If your manager needs a different agent version, override
+  WazuhAgentMSI with the MSI you want to deploy.
 
 author: Julian Hill - @julianghill
 type: CLIENT
 
+tools:
+  - name: WazuhAgentMSI
+    url: https://packages.wazuh.com/4.x/windows/wazuh-agent-4.14.5-1.msi
+    expected_hash: bf35197fee30092d78aad648299e8fd3aba8a0f9bc7d5edebce483a0b2c8e38e
+    version: 4.14.5
+    serve_locally: true
+
 required_permissions:
   - EXECVE
+  - FILESYSTEM_READ
   - FILESYSTEM_WRITE
 
 precondition: SELECT OS From info() where OS = 'windows'
@@ -36,22 +40,10 @@ parameters:
   - name: AgentGroup
     description: Optional Wazuh agent group or comma-separated groups.
     default: ""
-  - name: MsiUrl
-    description: Optional MSI URL override. If set, this takes precedence over WazuhVersion.
-    default: ""
-  - name: WazuhVersion
-    description: Optional Wazuh agent version to install, without the package release suffix. If empty, the artifact resolves the latest Wazuh release.
-    default: ""
-  - name: ExpectedSha256
-    description: Optional SHA256 expected hash for the downloaded MSI.
-    default: ""
-  - name: GithubReleaseApiUrl
-    description: GitHub API URL used to resolve the latest Wazuh release.
-    default: https://api.github.com/repos/wazuh/wazuh/releases/latest
   - name: UpdateExistingConfig
     type: bool
     description: Update ossec.conf with ManagerIP after installation when possible. Supports comma-separated managers.
-    default: N
+    default: Y
   - name: WazuhConfigPath
     description: Path to the Wazuh agent ossec.conf file.
     default: C:\Program Files (x86)\ossec-agent\ossec.conf
@@ -63,17 +55,18 @@ parameters:
     type: bool
     description: Upload the msiexec install log.
     default: Y
-  - name: DownloadTimeoutSec
-    type: int
-    description: Download timeout in seconds.
-    default: 300
 
 sources:
   - name: Install
     query: |
       LET TempDir <= tempdir()
-      LET MsiPath <= TempDir + "\\wazuh-agent.msi"
       LET LogPath <= TempDir + "\\wazuh-agent-install.log"
+
+      LET WazuhMSI <= SELECT FullPath, Name, DownloadStatus, Hash
+      FROM Artifact.Generic.Utils.FetchBinary(
+        ToolName="WazuhAgentMSI",
+        IsExecutable=FALSE
+      )
 
       LET EnvVars <= dict(
         WAZUH_MANAGER=ManagerIP,
@@ -81,15 +74,10 @@ sources:
         WAZUH_REGISTRATION_PASSWORD=RegistrationPassword,
         WAZUH_AGENT_NAME=AgentName,
         WAZUH_AGENT_GROUP=AgentGroup,
-        WAZUH_MSI_URL=MsiUrl,
-        WAZUH_VERSION=WazuhVersion,
-        WAZUH_EXPECTED_SHA256=ExpectedSha256,
-        WAZUH_GITHUB_RELEASE_API=GithubReleaseApiUrl,
         WAZUH_UPDATE_EXISTING_CONFIG=if(condition=UpdateExistingConfig, then="true", else="false"),
         WAZUH_CONFIG_PATH=WazuhConfigPath,
         WAZUH_START_SERVICE=if(condition=StartService, then="true", else="false"),
-        WAZUH_DOWNLOAD_TIMEOUT_SEC=str(str=DownloadTimeoutSec),
-        WAZUH_MSI_PATH=MsiPath,
+        WAZUH_MSI_PATH=str(str=WazuhMSI.FullPath[0]),
         WAZUH_INSTALL_LOG=LogPath,
         TEMP=TempDir,
         TMP=TempDir
@@ -142,21 +130,6 @@ sources:
         $Name + "=" + (Quote-ProcessArgument -Value $Value)
       }
 
-      function Get-WazuhMsiUrlFromVersion {
-        param([string] $Version)
-
-        $normalizedVersion = $Version -replace "^v", ""
-        if ($normalizedVersion -notmatch "^\d+\.\d+\.\d+$") {
-          throw "WazuhVersion '$Version' must be a semantic version such as 4.x.y. Set MsiUrl explicitly for other package names."
-        }
-
-        $major = $normalizedVersion.Split(".")[0]
-        [pscustomobject]@{
-          Version = $normalizedVersion
-          Url = "https://packages.wazuh.com/$major.x/windows/wazuh-agent-$normalizedVersion-1.msi"
-        }
-      }
-
       function Get-CommaSeparatedValues {
         param(
           [string] $Name,
@@ -190,13 +163,8 @@ sources:
       $registrationPassword = $env:WAZUH_REGISTRATION_PASSWORD
       $agentName = $env:WAZUH_AGENT_NAME
       $agentGroup = $env:WAZUH_AGENT_GROUP
-      $manualMsiUrl = $env:WAZUH_MSI_URL
-      $requestedVersion = $env:WAZUH_VERSION
-      $githubReleaseApi = $env:WAZUH_GITHUB_RELEASE_API
-      $expectedSha256 = $env:WAZUH_EXPECTED_SHA256
       $msiPath = $env:WAZUH_MSI_PATH
       $installLog = $env:WAZUH_INSTALL_LOG
-      $downloadTimeoutSec = [int]$env:WAZUH_DOWNLOAD_TIMEOUT_SEC
       $configPath = $env:WAZUH_CONFIG_PATH
       $updateExistingConfig = $env:WAZUH_UPDATE_EXISTING_CONFIG -eq "true"
       $startService = $env:WAZUH_START_SERVICE -eq "true"
@@ -206,10 +174,7 @@ sources:
       Assert-SafeArgument -Name "RegistrationPassword" -Value $registrationPassword
       Assert-SafeArgument -Name "AgentName" -Value $agentName
       Assert-SafeArgument -Name "AgentGroup" -Value $agentGroup
-      Assert-SafeArgument -Name "MsiUrl" -Value $manualMsiUrl
-      Assert-SafeArgument -Name "WazuhVersion" -Value $requestedVersion
-      Assert-SafeArgument -Name "ExpectedSha256" -Value $expectedSha256
-      Assert-SafeArgument -Name "GithubReleaseApiUrl" -Value $githubReleaseApi -Required $true
+      Assert-SafeArgument -Name "WazuhAgentMSI path" -Value $msiPath -Required $true
       Assert-SafeArgument -Name "WazuhConfigPath" -Value $configPath -Required $true
 
       $managerAddresses = @(Get-ManagerAddresses -ManagerList $manager)
@@ -230,61 +195,11 @@ sources:
         $agentGroup = (@(Get-CommaSeparatedValues -Name "AgentGroup" -Value $agentGroup) -join ",")
       }
 
-      $releaseTag = $null
-      $resolvedVersion = $null
-      $downloadSource = "manual"
-      $downloadUrl = $manualMsiUrl
-
-      if ([string]::IsNullOrWhiteSpace($downloadUrl)) {
-        if (-not [string]::IsNullOrWhiteSpace($requestedVersion)) {
-          $versionDetails = Get-WazuhMsiUrlFromVersion -Version $requestedVersion
-          $resolvedVersion = $versionDetails.Version
-          $downloadUrl = $versionDetails.Url
-          $downloadSource = "packages_wazuh_from_version"
-        } else {
-          $release = Invoke-RestMethod `
-            -Uri $githubReleaseApi `
-            -Headers @{ "User-Agent" = "Velociraptor-Wazuh-Installer" } `
-            -TimeoutSec $downloadTimeoutSec
-
-          $releaseTag = [string]$release.tag_name
-          Assert-RequiredValue -Name "GitHub release tag" -Value $releaseTag
-
-          $asset = @($release.assets) |
-            Where-Object { $_.name -match "^wazuh-agent-.+-1\.msi$" } |
-            Select-Object -First 1
-
-          if ($asset) {
-            $downloadUrl = [string]$asset.browser_download_url
-            $downloadSource = "github_release_asset"
-          } else {
-            $versionDetails = Get-WazuhMsiUrlFromVersion -Version $releaseTag
-            $resolvedVersion = $versionDetails.Version
-            $downloadUrl = $versionDetails.Url
-            $downloadSource = "packages_wazuh_from_github_tag"
-          }
-
-        }
+      if (-not (Test-Path -LiteralPath $msiPath)) {
+        throw "WazuhAgentMSI tool was not fetched to '$msiPath'."
       }
-
-      Assert-RequiredValue -Name "MSI download URL" -Value $downloadUrl
-
-      $parent = Split-Path -Parent $msiPath
-      if (-not (Test-Path -LiteralPath $parent)) {
-        New-Item -ItemType Directory -Path $parent -Force | Out-Null
-      }
-
-      Invoke-WebRequest `
-        -Uri $downloadUrl `
-        -OutFile $msiPath `
-        -UseBasicParsing `
-        -TimeoutSec $downloadTimeoutSec
 
       $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msiPath).Hash.ToLowerInvariant()
-      if (-not [string]::IsNullOrWhiteSpace($expectedSha256) -and
-          $actualSha256 -ne $expectedSha256.ToLowerInvariant()) {
-        throw "Downloaded MSI SHA256 '$actualSha256' did not match ExpectedSha256 '$expectedSha256'."
-      }
 
       $msiArguments = @(
         "/i",
@@ -406,11 +321,6 @@ sources:
         RegistrationPasswordSupplied = -not [string]::IsNullOrWhiteSpace($registrationPassword)
         AgentName = $agentName
         AgentGroup = $agentGroup
-        RequestedVersion = $requestedVersion
-        ResolvedVersion = $resolvedVersion
-        ReleaseTag = $releaseTag
-        DownloadSource = $downloadSource
-        MsiUrl = $downloadUrl
         MsiPath = $msiPath
         MsiSha256 = $actualSha256
         MsiExitCode = $process.ExitCode
@@ -447,13 +357,13 @@ sources:
           RegistrationPasswordSupplied=if(condition=RegistrationPassword, then=true, else=false),
           AgentName=AgentName,
           AgentGroup=AgentGroup,
-          MsiUrl=MsiUrl,
-          WazuhVersion=WazuhVersion,
-          GithubReleaseApiUrl=GithubReleaseApiUrl,
-          ExpectedSha256=ExpectedSha256,
+          WazuhAgentMSI=dict(
+            Name=WazuhMSI.Name[0],
+            DownloadStatus=WazuhMSI.DownloadStatus[0],
+            Sha256=WazuhMSI.Hash[0].SHA256
+          ),
           UpdateExistingConfig=UpdateExistingConfig,
           WazuhConfigPath=WazuhConfigPath,
-          StartService=StartService,
-          DownloadTimeoutSec=DownloadTimeoutSec
+          StartService=StartService
         ) AS RequestedSettings
       FROM Run

--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -40,13 +40,10 @@ parameters:
   - name: AgentGroup
     description: Optional Wazuh agent group or comma-separated groups.
     default: ""
-  - name: UpdateExistingConfig
+  - name: ReinstallExistingAgent
     type: bool
-    description: Update ossec.conf with ManagerIP after installation when possible. Supports comma-separated managers.
-    default: Y
-  - name: WazuhConfigPath
-    description: Path to the Wazuh agent ossec.conf file.
-    default: C:\Program Files (x86)\ossec-agent\ossec.conf
+    description: Reapply MSI properties when the Wazuh agent is already installed.
+    default: N
   - name: StartService
     type: bool
     description: Start or restart WazuhSvc after installation and configuration.
@@ -68,282 +65,103 @@ sources:
         IsExecutable=FALSE
       )
 
-      LET EnvVars <= dict(
-        WAZUH_MANAGER=ManagerIP,
-        WAZUH_REGISTRATION_SERVER=RegistrationServer,
-        WAZUH_REGISTRATION_PASSWORD=RegistrationPassword,
-        WAZUH_AGENT_NAME=AgentName,
-        WAZUH_AGENT_GROUP=AgentGroup,
-        WAZUH_UPDATE_EXISTING_CONFIG=if(condition=UpdateExistingConfig, then="true", else="false"),
-        WAZUH_CONFIG_PATH=WazuhConfigPath,
-        WAZUH_START_SERVICE=if(condition=StartService, then="true", else="false"),
-        WAZUH_MSI_PATH=str(str=WazuhMSI.FullPath[0]),
-        WAZUH_INSTALL_LOG=LogPath,
-        TEMP=TempDir,
-        TMP=TempDir
-      )
+      LET Trim(Value) = regex_replace(
+        source=Value,
+        re="^\\s+|\\s+$",
+        replace="")
 
-      LET PowershellScript = '''
-      $ErrorActionPreference = "Stop"
-      $ProgressPreference = "SilentlyContinue"
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+      LET ManagerAddresses <= SELECT Trim(Value=_value) AS Address
+      FROM foreach(row=split(string=ManagerIP, sep=","))
+      WHERE Address
 
-      function Assert-RequiredValue {
-        param(
-          [string] $Name,
-          [string] $Value
-        )
+      LET RegistrationServerAddresses <= SELECT Trim(Value=_value) AS Address
+      FROM foreach(row=split(string=RegistrationServer, sep=","))
+      WHERE Address
 
-        if ([string]::IsNullOrWhiteSpace($Value)) {
-          throw "$Name is required."
-        }
-      }
+      LET AgentGroups <= SELECT Trim(Value=_value) AS GroupName
+      FROM foreach(row=split(string=AgentGroup, sep=","))
+      WHERE GroupName
 
-      function Assert-SafeArgument {
-        param(
-          [string] $Name,
-          [string] $Value,
-          [bool] $Required = $false
-        )
+      LET ManagerFinal <= join(array=ManagerAddresses.Address, sep=",")
+      LET RegistrationServerFinal <= if(
+        condition=RegistrationServerAddresses.Address[0],
+        then=RegistrationServerAddresses.Address[0],
+        else=ManagerAddresses.Address[0])
+      LET AgentGroupFinal <= join(array=AgentGroups.GroupName, sep=",")
 
-        if ($Required) {
-          Assert-RequiredValue -Name $Name -Value $Value
-        }
+      LET ValidationError <= if(
+        condition=NOT ManagerFinal,
+        then="ManagerIP is required.",
+        else=if(
+          condition=len(list=RegistrationServerAddresses.Address) > 1,
+          then="RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses.",
+          else=if(
+            condition=NOT WazuhMSI.FullPath[0],
+            then="WazuhAgentMSI tool was not fetched.")))
 
-        if (-not [string]::IsNullOrEmpty($Value) -and $Value -match "[`r`n`"]") {
-          throw "$Name contains an unsupported character."
-        }
-      }
-
-      function Quote-ProcessArgument {
-        param([string] $Value)
-
-        '"' + ($Value -replace '"', '\"') + '"'
-      }
-
-      function New-MsiPropertyArgument {
-        param(
-          [string] $Name,
-          [string] $Value
-        )
-
-        $Name + "=" + (Quote-ProcessArgument -Value $Value)
-      }
-
-      function Get-CommaSeparatedValues {
-        param(
-          [string] $Name,
-          [string] $Value
-        )
-
-        $values = @($Value -split "," |
-          ForEach-Object { $_.Trim() } |
-          Where-Object { $_.Length -gt 0 })
-
-        if ($values.Count -eq 0) {
-          throw "$Name did not contain a usable value."
-        }
-
-        $values
-      }
-
-      function Get-ManagerAddresses {
-        param([string] $ManagerList)
-
-        $addresses = @(Get-CommaSeparatedValues -Name "ManagerIP" -Value $ManagerList)
-        if ($addresses.Count -eq 0) {
-          throw "ManagerIP did not contain a usable manager address."
-        }
-
-        $addresses
-      }
-
-      $manager = $env:WAZUH_MANAGER
-      $registrationServer = $env:WAZUH_REGISTRATION_SERVER
-      $registrationPassword = $env:WAZUH_REGISTRATION_PASSWORD
-      $agentName = $env:WAZUH_AGENT_NAME
-      $agentGroup = $env:WAZUH_AGENT_GROUP
-      $msiPath = $env:WAZUH_MSI_PATH
-      $installLog = $env:WAZUH_INSTALL_LOG
-      $configPath = $env:WAZUH_CONFIG_PATH
-      $updateExistingConfig = $env:WAZUH_UPDATE_EXISTING_CONFIG -eq "true"
-      $startService = $env:WAZUH_START_SERVICE -eq "true"
-
-      Assert-SafeArgument -Name "ManagerIP" -Value $manager -Required $true
-      Assert-SafeArgument -Name "RegistrationServer" -Value $registrationServer
-      Assert-SafeArgument -Name "RegistrationPassword" -Value $registrationPassword
-      Assert-SafeArgument -Name "AgentName" -Value $agentName
-      Assert-SafeArgument -Name "AgentGroup" -Value $agentGroup
-      Assert-SafeArgument -Name "WazuhAgentMSI path" -Value $msiPath -Required $true
-      Assert-SafeArgument -Name "WazuhConfigPath" -Value $configPath -Required $true
-
-      $managerAddresses = @(Get-ManagerAddresses -ManagerList $manager)
-      $manager = $managerAddresses -join ","
-
-      if ([string]::IsNullOrWhiteSpace($registrationServer)) {
-        $registrationServer = $managerAddresses[0]
-      } else {
-        $registrationServerAddresses = @(Get-CommaSeparatedValues -Name "RegistrationServer" -Value $registrationServer)
-        if ($registrationServerAddresses.Count -gt 1) {
-          throw "RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses."
-        }
-
-        $registrationServer = $registrationServerAddresses[0]
-      }
-
-      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
-        $agentGroup = (@(Get-CommaSeparatedValues -Name "AgentGroup" -Value $agentGroup) -join ",")
-      }
-
-      if (-not (Test-Path -LiteralPath $msiPath)) {
-        throw "WazuhAgentMSI tool was not fetched to '$msiPath'."
-      }
-
-      $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msiPath).Hash.ToLowerInvariant()
-
-      $msiArguments = @(
+      LET MsiArgs <= filter(list=(
+        "msiexec.exe",
         "/i",
-        (Quote-ProcessArgument -Value $msiPath),
+        WazuhMSI.FullPath[0],
         "/qn",
         "/norestart",
         "/l*v",
-        (Quote-ProcessArgument -Value $installLog),
-        (New-MsiPropertyArgument -Name "WAZUH_MANAGER" -Value $manager),
-        (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_SERVER" -Value $registrationServer)
-      )
+        LogPath,
+        "WAZUH_MANAGER=" + ManagerFinal,
+        "WAZUH_REGISTRATION_SERVER=" + RegistrationServerFinal,
+        if(condition=ReinstallExistingAgent, then="REINSTALL=ALL"),
+        if(condition=ReinstallExistingAgent, then="REINSTALLMODE=vomus"),
+        if(condition=RegistrationPassword, then="WAZUH_REGISTRATION_PASSWORD=" + RegistrationPassword),
+        if(condition=AgentName, then="WAZUH_AGENT_NAME=" + AgentName),
+        if(condition=AgentGroupFinal, then="WAZUH_AGENT_GROUP=" + AgentGroupFinal)
+      ), regex=".+")
 
-      if (-not [string]::IsNullOrWhiteSpace($registrationPassword)) {
-        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_PASSWORD" -Value $registrationPassword)
-      }
+      LET Run <= SELECT *
+      FROM if(
+        condition=ValidationError,
+        then={
+          SELECT "" AS Stdout,
+            ValidationError AS Stderr,
+            1 AS ReturnCode,
+            true AS Complete
+          FROM scope()
+        },
+        else={
+          SELECT *
+          FROM execve(argv=MsiArgs, length=1000000)
+        })
 
-      if (-not [string]::IsNullOrWhiteSpace($agentName)) {
-        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_NAME" -Value $agentName)
-      }
+      LET ServiceActions <= SELECT *
+      FROM if(
+        condition=StartService AND Run.ReturnCode[0] = 0,
+        then={
+          SELECT *
+          FROM chain(
+            stop={
+              SELECT "stop" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["sc.exe", "stop", "WazuhSvc"], length=100000)
+            },
+            wait={
+              SELECT "wait" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["ping.exe", "-n", "6", "127.0.0.1"], length=100000)
+            },
+            start={
+              SELECT "start" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["sc.exe", "start", "WazuhSvc"], length=100000)
+            },
+            query={
+              SELECT "query" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["sc.exe", "query", "WazuhSvc"], length=100000)
+            })
+        })
 
-      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
-        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_GROUP" -Value $agentGroup)
-      }
+      LET ServiceSummary <= SELECT *
+      FROM foreach(row=ServiceActions)
 
-      $process = Start-Process `
-        -FilePath "msiexec.exe" `
-        -ArgumentList $msiArguments `
-        -Wait `
-        -PassThru
-
-      if ($process.ExitCode -ne 0) {
-        throw "msiexec.exe failed with exit code $($process.ExitCode)."
-      }
-
-      $configUpdated = $false
-      $configUpdateStatus = "not_requested"
-      if ($updateExistingConfig -and (Test-Path -LiteralPath $configPath)) {
-        [xml]$config = Get-Content -LiteralPath $configPath
-        $root = $config.SelectSingleNode("/ossec_config")
-        if ($null -eq $root) {
-          throw "Unable to update '$configPath': missing /ossec_config root element."
-        }
-
-        $client = $config.SelectSingleNode("/ossec_config/client")
-        if ($null -eq $client) {
-          $client = $config.CreateElement("client")
-          [void]$root.AppendChild($client)
-          $configUpdated = $true
-        }
-
-        $servers = @($client.SelectNodes("server"))
-        if ($servers.Count -eq 0) {
-          $server = $config.CreateElement("server")
-          [void]$client.AppendChild($server)
-          $servers = @($server)
-          $configUpdated = $true
-        }
-
-        $template = $servers[0]
-        for ($i = 0; $i -lt $managerAddresses.Count; $i++) {
-          if ($i -lt $servers.Count) {
-            $server = $servers[$i]
-          } else {
-            $server = $template.CloneNode($true)
-            [void]$client.AppendChild($server)
-            $configUpdated = $true
-          }
-
-          $address = $server.SelectSingleNode("address")
-          if ($null -eq $address) {
-            $address = $config.CreateElement("address")
-            if ($server.HasChildNodes) {
-              [void]$server.InsertBefore($address, $server.FirstChild)
-            } else {
-              [void]$server.AppendChild($address)
-            }
-            $configUpdated = $true
-          }
-
-          if ($address.InnerText -ne $managerAddresses[$i]) {
-            $address.InnerText = $managerAddresses[$i]
-            $configUpdated = $true
-          }
-        }
-
-        if ($servers.Count -gt $managerAddresses.Count) {
-          for ($i = $servers.Count - 1; $i -ge $managerAddresses.Count; $i--) {
-            [void]$client.RemoveChild($servers[$i])
-            $configUpdated = $true
-          }
-        }
-
-        if ($configUpdated) {
-          $config.Save($configPath)
-          $configUpdateStatus = "updated"
-        } else {
-          $configUpdateStatus = "already_current"
-        }
-      } elseif ($updateExistingConfig) {
-        $configUpdateStatus = "missing_config"
-      }
-
-      $serviceStatus = "not_requested"
-      if ($startService) {
-        $service = Get-Service -Name "WazuhSvc" -ErrorAction Stop
-        if ($service.Status -eq "Running") {
-          Restart-Service -Name "WazuhSvc" -Force -ErrorAction Stop
-        } else {
-          Start-Service -Name "WazuhSvc" -ErrorAction Stop
-        }
-
-        $serviceStatus = (Get-Service -Name "WazuhSvc" -ErrorAction Stop).Status.ToString()
-      }
-
-      [ordered]@{
-        Status = "Installed"
-        ManagerIP = $manager
-        RegistrationServer = $registrationServer
-        RegistrationPasswordSupplied = -not [string]::IsNullOrWhiteSpace($registrationPassword)
-        AgentName = $agentName
-        AgentGroup = $agentGroup
-        MsiPath = $msiPath
-        MsiSha256 = $actualSha256
-        MsiExitCode = $process.ExitCode
-        ConfigPath = $configPath
-        ConfigUpdated = $configUpdated
-        ConfigUpdateStatus = $configUpdateStatus
-        ServiceStatus = $serviceStatus
-        InstallLog = $installLog
-      } | ConvertTo-Json -Compress
-      '''
-
-      LET Run <= SELECT Stdout, Stderr, ReturnCode, Complete
-      FROM execve(
-        argv=[
-          "powershell.exe",
-          "-NoProfile",
-          "-NonInteractive",
-          "-ExecutionPolicy", "Bypass",
-          "-Command", PowershellScript
-        ],
-        env=EnvVars,
-        length=1000000
-      )
+      LET ServiceStatus <= if(
+        condition=StartService AND Run.ReturnCode[0] = 0,
+        then=ServiceSummary.Stdout[-1],
+        else="not_requested")
 
       LET LogUpload <= SELECT upload(file=OSPath) AS Upload
       FROM glob(globs=LogPath)
@@ -351,19 +169,20 @@ sources:
 
       SELECT Stdout, Stderr, ReturnCode, Complete,
         LogUpload.Upload[0] AS InstallLog,
+        ServiceSummary AS ServiceActions,
         dict(
-          ManagerIP=ManagerIP,
-          RegistrationServer=RegistrationServer,
+          ManagerIP=ManagerFinal,
+          RegistrationServer=RegistrationServerFinal,
           RegistrationPasswordSupplied=if(condition=RegistrationPassword, then=true, else=false),
           AgentName=AgentName,
-          AgentGroup=AgentGroup,
+          AgentGroup=AgentGroupFinal,
           WazuhAgentMSI=dict(
             Name=WazuhMSI.Name[0],
             DownloadStatus=WazuhMSI.DownloadStatus[0],
             Sha256=WazuhMSI.Hash[0].SHA256
           ),
-          UpdateExistingConfig=UpdateExistingConfig,
-          WazuhConfigPath=WazuhConfigPath,
-          StartService=StartService
+          ReinstallExistingAgent=ReinstallExistingAgent,
+          StartService=StartService,
+          ServiceStatus=ServiceStatus
         ) AS RequestedSettings
       FROM Run

--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -40,10 +40,13 @@ parameters:
   - name: AgentGroup
     description: Optional Wazuh agent group or comma-separated groups.
     default: ""
-  - name: ReinstallExistingAgent
+  - name: UpdateExistingConfig
     type: bool
-    description: Reapply MSI properties when the Wazuh agent is already installed.
+    description: Update ossec.conf with ManagerIP after installation when possible. Supports comma-separated managers.
     default: Y
+  - name: WazuhConfigPath
+    description: Path to the Wazuh agent ossec.conf file.
+    default: C:\Program Files (x86)\ossec-agent\ossec.conf
   - name: StartService
     type: bool
     description: Start or restart WazuhSvc after installation and configuration.
@@ -65,103 +68,282 @@ sources:
         IsExecutable=FALSE
       )
 
-      LET Trim(Value) = regex_replace(
-        source=Value,
-        re="^\\s+|\\s+$",
-        replace="")
+      LET EnvVars <= dict(
+        WAZUH_MANAGER=ManagerIP,
+        WAZUH_REGISTRATION_SERVER=RegistrationServer,
+        WAZUH_REGISTRATION_PASSWORD=RegistrationPassword,
+        WAZUH_AGENT_NAME=AgentName,
+        WAZUH_AGENT_GROUP=AgentGroup,
+        WAZUH_UPDATE_EXISTING_CONFIG=if(condition=UpdateExistingConfig, then="true", else="false"),
+        WAZUH_CONFIG_PATH=WazuhConfigPath,
+        WAZUH_START_SERVICE=if(condition=StartService, then="true", else="false"),
+        WAZUH_MSI_PATH=str(str=WazuhMSI.FullPath[0]),
+        WAZUH_INSTALL_LOG=LogPath,
+        TEMP=TempDir,
+        TMP=TempDir
+      )
 
-      LET ManagerAddresses <= SELECT Trim(Value=_value) AS Address
-      FROM foreach(row=split(string=ManagerIP, sep=","))
-      WHERE Address
+      LET PowershellScript = '''
+      $ErrorActionPreference = "Stop"
+      $ProgressPreference = "SilentlyContinue"
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-      LET RegistrationServerAddresses <= SELECT Trim(Value=_value) AS Address
-      FROM foreach(row=split(string=RegistrationServer, sep=","))
-      WHERE Address
+      function Assert-RequiredValue {
+        param(
+          [string] $Name,
+          [string] $Value
+        )
 
-      LET AgentGroups <= SELECT Trim(Value=_value) AS GroupName
-      FROM foreach(row=split(string=AgentGroup, sep=","))
-      WHERE GroupName
+        if ([string]::IsNullOrWhiteSpace($Value)) {
+          throw "$Name is required."
+        }
+      }
 
-      LET ManagerFinal <= join(array=ManagerAddresses.Address, sep=",")
-      LET RegistrationServerFinal <= if(
-        condition=RegistrationServerAddresses.Address[0],
-        then=RegistrationServerAddresses.Address[0],
-        else=ManagerAddresses.Address[0])
-      LET AgentGroupFinal <= join(array=AgentGroups.GroupName, sep=",")
+      function Assert-SafeArgument {
+        param(
+          [string] $Name,
+          [string] $Value,
+          [bool] $Required = $false
+        )
 
-      LET ValidationError <= if(
-        condition=NOT ManagerFinal,
-        then="ManagerIP is required.",
-        else=if(
-          condition=len(list=RegistrationServerAddresses.Address) > 1,
-          then="RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses.",
-          else=if(
-            condition=NOT WazuhMSI.FullPath[0],
-            then="WazuhAgentMSI tool was not fetched.")))
+        if ($Required) {
+          Assert-RequiredValue -Name $Name -Value $Value
+        }
 
-      LET MsiArgs <= filter(list=(
-        "msiexec.exe",
+        if (-not [string]::IsNullOrEmpty($Value) -and $Value -match "[`r`n`"]") {
+          throw "$Name contains an unsupported character."
+        }
+      }
+
+      function Quote-ProcessArgument {
+        param([string] $Value)
+
+        '"' + ($Value -replace '"', '\"') + '"'
+      }
+
+      function New-MsiPropertyArgument {
+        param(
+          [string] $Name,
+          [string] $Value
+        )
+
+        $Name + "=" + (Quote-ProcessArgument -Value $Value)
+      }
+
+      function Get-CommaSeparatedValues {
+        param(
+          [string] $Name,
+          [string] $Value
+        )
+
+        $values = @($Value -split "," |
+          ForEach-Object { $_.Trim() } |
+          Where-Object { $_.Length -gt 0 })
+
+        if ($values.Count -eq 0) {
+          throw "$Name did not contain a usable value."
+        }
+
+        $values
+      }
+
+      function Get-ManagerAddresses {
+        param([string] $ManagerList)
+
+        $addresses = @(Get-CommaSeparatedValues -Name "ManagerIP" -Value $ManagerList)
+        if ($addresses.Count -eq 0) {
+          throw "ManagerIP did not contain a usable manager address."
+        }
+
+        $addresses
+      }
+
+      $manager = $env:WAZUH_MANAGER
+      $registrationServer = $env:WAZUH_REGISTRATION_SERVER
+      $registrationPassword = $env:WAZUH_REGISTRATION_PASSWORD
+      $agentName = $env:WAZUH_AGENT_NAME
+      $agentGroup = $env:WAZUH_AGENT_GROUP
+      $msiPath = $env:WAZUH_MSI_PATH
+      $installLog = $env:WAZUH_INSTALL_LOG
+      $configPath = $env:WAZUH_CONFIG_PATH
+      $updateExistingConfig = $env:WAZUH_UPDATE_EXISTING_CONFIG -eq "true"
+      $startService = $env:WAZUH_START_SERVICE -eq "true"
+
+      Assert-SafeArgument -Name "ManagerIP" -Value $manager -Required $true
+      Assert-SafeArgument -Name "RegistrationServer" -Value $registrationServer
+      Assert-SafeArgument -Name "RegistrationPassword" -Value $registrationPassword
+      Assert-SafeArgument -Name "AgentName" -Value $agentName
+      Assert-SafeArgument -Name "AgentGroup" -Value $agentGroup
+      Assert-SafeArgument -Name "WazuhAgentMSI path" -Value $msiPath -Required $true
+      Assert-SafeArgument -Name "WazuhConfigPath" -Value $configPath -Required $true
+
+      $managerAddresses = @(Get-ManagerAddresses -ManagerList $manager)
+      $manager = $managerAddresses -join ","
+
+      if ([string]::IsNullOrWhiteSpace($registrationServer)) {
+        $registrationServer = $managerAddresses[0]
+      } else {
+        $registrationServerAddresses = @(Get-CommaSeparatedValues -Name "RegistrationServer" -Value $registrationServer)
+        if ($registrationServerAddresses.Count -gt 1) {
+          throw "RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses."
+        }
+
+        $registrationServer = $registrationServerAddresses[0]
+      }
+
+      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
+        $agentGroup = (@(Get-CommaSeparatedValues -Name "AgentGroup" -Value $agentGroup) -join ",")
+      }
+
+      if (-not (Test-Path -LiteralPath $msiPath)) {
+        throw "WazuhAgentMSI tool was not fetched to '$msiPath'."
+      }
+
+      $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msiPath).Hash.ToLowerInvariant()
+
+      $msiArguments = @(
         "/i",
-        WazuhMSI.FullPath[0],
+        (Quote-ProcessArgument -Value $msiPath),
         "/qn",
         "/norestart",
         "/l*v",
-        LogPath,
-        "WAZUH_MANAGER=" + ManagerFinal,
-        "WAZUH_REGISTRATION_SERVER=" + RegistrationServerFinal,
-        if(condition=ReinstallExistingAgent, then="REINSTALL=ALL"),
-        if(condition=ReinstallExistingAgent, then="REINSTALLMODE=vomus"),
-        if(condition=RegistrationPassword, then="WAZUH_REGISTRATION_PASSWORD=" + RegistrationPassword),
-        if(condition=AgentName, then="WAZUH_AGENT_NAME=" + AgentName),
-        if(condition=AgentGroupFinal, then="WAZUH_AGENT_GROUP=" + AgentGroupFinal)
-      ), regex=".+")
+        (Quote-ProcessArgument -Value $installLog),
+        (New-MsiPropertyArgument -Name "WAZUH_MANAGER" -Value $manager),
+        (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_SERVER" -Value $registrationServer)
+      )
 
-      LET Run <= SELECT *
-      FROM if(
-        condition=ValidationError,
-        then={
-          SELECT "" AS Stdout,
-            ValidationError AS Stderr,
-            1 AS ReturnCode,
-            true AS Complete
-          FROM scope()
-        },
-        else={
-          SELECT *
-          FROM execve(argv=MsiArgs, length=1000000)
-        })
+      if (-not [string]::IsNullOrWhiteSpace($registrationPassword)) {
+        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_PASSWORD" -Value $registrationPassword)
+      }
 
-      LET ServiceActions <= SELECT *
-      FROM if(
-        condition=StartService AND Run.ReturnCode[0] = 0,
-        then={
-          SELECT *
-          FROM chain(
-            stop={
-              SELECT "stop" AS Action, Stdout, Stderr, ReturnCode, Complete
-              FROM execve(argv=["sc.exe", "stop", "WazuhSvc"], length=100000)
-            },
-            wait={
-              SELECT "wait" AS Action, Stdout, Stderr, ReturnCode, Complete
-              FROM execve(argv=["ping.exe", "-n", "6", "127.0.0.1"], length=100000)
-            },
-            start={
-              SELECT "start" AS Action, Stdout, Stderr, ReturnCode, Complete
-              FROM execve(argv=["sc.exe", "start", "WazuhSvc"], length=100000)
-            },
-            query={
-              SELECT "query" AS Action, Stdout, Stderr, ReturnCode, Complete
-              FROM execve(argv=["sc.exe", "query", "WazuhSvc"], length=100000)
-            })
-        })
+      if (-not [string]::IsNullOrWhiteSpace($agentName)) {
+        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_NAME" -Value $agentName)
+      }
 
-      LET ServiceSummary <= SELECT *
-      FROM foreach(row=ServiceActions)
+      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
+        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_GROUP" -Value $agentGroup)
+      }
 
-      LET ServiceStatus <= if(
-        condition=StartService AND Run.ReturnCode[0] = 0,
-        then=ServiceSummary.Stdout[-1],
-        else="not_requested")
+      $process = Start-Process `
+        -FilePath "msiexec.exe" `
+        -ArgumentList $msiArguments `
+        -Wait `
+        -PassThru
+
+      if ($process.ExitCode -ne 0) {
+        throw "msiexec.exe failed with exit code $($process.ExitCode)."
+      }
+
+      $configUpdated = $false
+      $configUpdateStatus = "not_requested"
+      if ($updateExistingConfig -and (Test-Path -LiteralPath $configPath)) {
+        [xml]$config = Get-Content -LiteralPath $configPath
+        $root = $config.SelectSingleNode("/ossec_config")
+        if ($null -eq $root) {
+          throw "Unable to update '$configPath': missing /ossec_config root element."
+        }
+
+        $client = $config.SelectSingleNode("/ossec_config/client")
+        if ($null -eq $client) {
+          $client = $config.CreateElement("client")
+          [void]$root.AppendChild($client)
+          $configUpdated = $true
+        }
+
+        $servers = @($client.SelectNodes("server"))
+        if ($servers.Count -eq 0) {
+          $server = $config.CreateElement("server")
+          [void]$client.AppendChild($server)
+          $servers = @($server)
+          $configUpdated = $true
+        }
+
+        $template = $servers[0]
+        for ($i = 0; $i -lt $managerAddresses.Count; $i++) {
+          if ($i -lt $servers.Count) {
+            $server = $servers[$i]
+          } else {
+            $server = $template.CloneNode($true)
+            [void]$client.AppendChild($server)
+            $configUpdated = $true
+          }
+
+          $address = $server.SelectSingleNode("address")
+          if ($null -eq $address) {
+            $address = $config.CreateElement("address")
+            if ($server.HasChildNodes) {
+              [void]$server.InsertBefore($address, $server.FirstChild)
+            } else {
+              [void]$server.AppendChild($address)
+            }
+            $configUpdated = $true
+          }
+
+          if ($address.InnerText -ne $managerAddresses[$i]) {
+            $address.InnerText = $managerAddresses[$i]
+            $configUpdated = $true
+          }
+        }
+
+        if ($servers.Count -gt $managerAddresses.Count) {
+          for ($i = $servers.Count - 1; $i -ge $managerAddresses.Count; $i--) {
+            [void]$client.RemoveChild($servers[$i])
+            $configUpdated = $true
+          }
+        }
+
+        if ($configUpdated) {
+          $config.Save($configPath)
+          $configUpdateStatus = "updated"
+        } else {
+          $configUpdateStatus = "already_current"
+        }
+      } elseif ($updateExistingConfig) {
+        $configUpdateStatus = "missing_config"
+      }
+
+      $serviceStatus = "not_requested"
+      if ($startService) {
+        $service = Get-Service -Name "WazuhSvc" -ErrorAction Stop
+        if ($service.Status -eq "Running") {
+          Restart-Service -Name "WazuhSvc" -Force -ErrorAction Stop
+        } else {
+          Start-Service -Name "WazuhSvc" -ErrorAction Stop
+        }
+
+        $serviceStatus = (Get-Service -Name "WazuhSvc" -ErrorAction Stop).Status.ToString()
+      }
+
+      [ordered]@{
+        Status = "Installed"
+        ManagerIP = $manager
+        RegistrationServer = $registrationServer
+        RegistrationPasswordSupplied = -not [string]::IsNullOrWhiteSpace($registrationPassword)
+        AgentName = $agentName
+        AgentGroup = $agentGroup
+        MsiPath = $msiPath
+        MsiSha256 = $actualSha256
+        MsiExitCode = $process.ExitCode
+        ConfigPath = $configPath
+        ConfigUpdated = $configUpdated
+        ConfigUpdateStatus = $configUpdateStatus
+        ServiceStatus = $serviceStatus
+        InstallLog = $installLog
+      } | ConvertTo-Json -Compress
+      '''
+
+      LET Run <= SELECT Stdout, Stderr, ReturnCode, Complete
+      FROM execve(
+        argv=[
+          "powershell.exe",
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy", "Bypass",
+          "-Command", PowershellScript
+        ],
+        env=EnvVars,
+        length=1000000
+      )
 
       LET LogUpload <= SELECT upload(file=OSPath) AS Upload
       FROM glob(globs=LogPath)
@@ -169,20 +351,19 @@ sources:
 
       SELECT Stdout, Stderr, ReturnCode, Complete,
         LogUpload.Upload[0] AS InstallLog,
-        ServiceSummary AS ServiceActions,
         dict(
-          ManagerIP=ManagerFinal,
-          RegistrationServer=RegistrationServerFinal,
+          ManagerIP=ManagerIP,
+          RegistrationServer=RegistrationServer,
           RegistrationPasswordSupplied=if(condition=RegistrationPassword, then=true, else=false),
           AgentName=AgentName,
-          AgentGroup=AgentGroupFinal,
+          AgentGroup=AgentGroup,
           WazuhAgentMSI=dict(
             Name=WazuhMSI.Name[0],
             DownloadStatus=WazuhMSI.DownloadStatus[0],
             Sha256=WazuhMSI.Hash[0].SHA256
           ),
-          ReinstallExistingAgent=ReinstallExistingAgent,
-          StartService=StartService,
-          ServiceStatus=ServiceStatus
+          UpdateExistingConfig=UpdateExistingConfig,
+          WazuhConfigPath=WazuhConfigPath,
+          StartService=StartService
         ) AS RequestedSettings
       FROM Run

--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -80,30 +80,24 @@ sources:
       FROM ManagerIP
       WHERE IP
 
-      LET RegistrationServerAddresses = SELECT Trim(Value=_value) AS Address
-      FROM foreach(row=split(string=RegistrationServer, sep=","))
-      WHERE Address
+      LET RegistrationServerFinal = if(
+        condition=Trim(Value=RegistrationServer),
+        then=Trim(Value=RegistrationServer),
+        else=ManagerAddresses.IP[0])
 
       LET AgentGroups = SELECT Trim(Value=Group) AS Group
       FROM AgentGroup
       WHERE Group
 
       LET ManagerFinal = join(array=ManagerAddresses.IP, sep=",")
-      LET RegistrationServerFinal = if(
-        condition=RegistrationServerAddresses.Address[0],
-        then=RegistrationServerAddresses.Address[0],
-        else=ManagerAddresses.IP[0])
       LET AgentGroupFinal = join(array=AgentGroups.Group, sep=",")
 
       LET ValidationError = if(
         condition=NOT ManagerFinal,
         then="ManagerIP is required.",
         else=if(
-          condition=len(list=RegistrationServerAddresses.Address) > 1,
-          then="RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses.",
-          else=if(
-            condition=NOT WazuhMSI.FullPath[0],
-            then="WazuhAgentMSI tool was not fetched.")))
+          condition=NOT WazuhMSI.FullPath[0],
+          then="WazuhAgentMSI tool was not fetched."))
 
       LET MsiArgs = filter(list=(
         "msiexec.exe",

--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -40,13 +40,10 @@ parameters:
   - name: AgentGroup
     description: Optional Wazuh agent group or comma-separated groups.
     default: ""
-  - name: UpdateExistingConfig
+  - name: ReinstallExistingAgent
     type: bool
-    description: Update ossec.conf with ManagerIP after installation when possible. Supports comma-separated managers.
+    description: Reapply MSI properties when the Wazuh agent is already installed.
     default: Y
-  - name: WazuhConfigPath
-    description: Path to the Wazuh agent ossec.conf file.
-    default: C:\Program Files (x86)\ossec-agent\ossec.conf
   - name: StartService
     type: bool
     description: Start or restart WazuhSvc after installation and configuration.
@@ -68,282 +65,103 @@ sources:
         IsExecutable=FALSE
       )
 
-      LET EnvVars <= dict(
-        WAZUH_MANAGER=ManagerIP,
-        WAZUH_REGISTRATION_SERVER=RegistrationServer,
-        WAZUH_REGISTRATION_PASSWORD=RegistrationPassword,
-        WAZUH_AGENT_NAME=AgentName,
-        WAZUH_AGENT_GROUP=AgentGroup,
-        WAZUH_UPDATE_EXISTING_CONFIG=if(condition=UpdateExistingConfig, then="true", else="false"),
-        WAZUH_CONFIG_PATH=WazuhConfigPath,
-        WAZUH_START_SERVICE=if(condition=StartService, then="true", else="false"),
-        WAZUH_MSI_PATH=str(str=WazuhMSI.FullPath[0]),
-        WAZUH_INSTALL_LOG=LogPath,
-        TEMP=TempDir,
-        TMP=TempDir
-      )
+      LET Trim(Value) = regex_replace(
+        source=Value,
+        re="^\\s+|\\s+$",
+        replace="")
 
-      LET PowershellScript = '''
-      $ErrorActionPreference = "Stop"
-      $ProgressPreference = "SilentlyContinue"
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+      LET ManagerAddresses <= SELECT Trim(Value=_value) AS Address
+      FROM foreach(row=split(string=ManagerIP, sep=","))
+      WHERE Address
 
-      function Assert-RequiredValue {
-        param(
-          [string] $Name,
-          [string] $Value
-        )
+      LET RegistrationServerAddresses <= SELECT Trim(Value=_value) AS Address
+      FROM foreach(row=split(string=RegistrationServer, sep=","))
+      WHERE Address
 
-        if ([string]::IsNullOrWhiteSpace($Value)) {
-          throw "$Name is required."
-        }
-      }
+      LET AgentGroups <= SELECT Trim(Value=_value) AS GroupName
+      FROM foreach(row=split(string=AgentGroup, sep=","))
+      WHERE GroupName
 
-      function Assert-SafeArgument {
-        param(
-          [string] $Name,
-          [string] $Value,
-          [bool] $Required = $false
-        )
+      LET ManagerFinal <= join(array=ManagerAddresses.Address, sep=",")
+      LET RegistrationServerFinal <= if(
+        condition=RegistrationServerAddresses.Address[0],
+        then=RegistrationServerAddresses.Address[0],
+        else=ManagerAddresses.Address[0])
+      LET AgentGroupFinal <= join(array=AgentGroups.GroupName, sep=",")
 
-        if ($Required) {
-          Assert-RequiredValue -Name $Name -Value $Value
-        }
+      LET ValidationError <= if(
+        condition=NOT ManagerFinal,
+        then="ManagerIP is required.",
+        else=if(
+          condition=len(list=RegistrationServerAddresses.Address) > 1,
+          then="RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses.",
+          else=if(
+            condition=NOT WazuhMSI.FullPath[0],
+            then="WazuhAgentMSI tool was not fetched.")))
 
-        if (-not [string]::IsNullOrEmpty($Value) -and $Value -match "[`r`n`"]") {
-          throw "$Name contains an unsupported character."
-        }
-      }
-
-      function Quote-ProcessArgument {
-        param([string] $Value)
-
-        '"' + ($Value -replace '"', '\"') + '"'
-      }
-
-      function New-MsiPropertyArgument {
-        param(
-          [string] $Name,
-          [string] $Value
-        )
-
-        $Name + "=" + (Quote-ProcessArgument -Value $Value)
-      }
-
-      function Get-CommaSeparatedValues {
-        param(
-          [string] $Name,
-          [string] $Value
-        )
-
-        $values = @($Value -split "," |
-          ForEach-Object { $_.Trim() } |
-          Where-Object { $_.Length -gt 0 })
-
-        if ($values.Count -eq 0) {
-          throw "$Name did not contain a usable value."
-        }
-
-        $values
-      }
-
-      function Get-ManagerAddresses {
-        param([string] $ManagerList)
-
-        $addresses = @(Get-CommaSeparatedValues -Name "ManagerIP" -Value $ManagerList)
-        if ($addresses.Count -eq 0) {
-          throw "ManagerIP did not contain a usable manager address."
-        }
-
-        $addresses
-      }
-
-      $manager = $env:WAZUH_MANAGER
-      $registrationServer = $env:WAZUH_REGISTRATION_SERVER
-      $registrationPassword = $env:WAZUH_REGISTRATION_PASSWORD
-      $agentName = $env:WAZUH_AGENT_NAME
-      $agentGroup = $env:WAZUH_AGENT_GROUP
-      $msiPath = $env:WAZUH_MSI_PATH
-      $installLog = $env:WAZUH_INSTALL_LOG
-      $configPath = $env:WAZUH_CONFIG_PATH
-      $updateExistingConfig = $env:WAZUH_UPDATE_EXISTING_CONFIG -eq "true"
-      $startService = $env:WAZUH_START_SERVICE -eq "true"
-
-      Assert-SafeArgument -Name "ManagerIP" -Value $manager -Required $true
-      Assert-SafeArgument -Name "RegistrationServer" -Value $registrationServer
-      Assert-SafeArgument -Name "RegistrationPassword" -Value $registrationPassword
-      Assert-SafeArgument -Name "AgentName" -Value $agentName
-      Assert-SafeArgument -Name "AgentGroup" -Value $agentGroup
-      Assert-SafeArgument -Name "WazuhAgentMSI path" -Value $msiPath -Required $true
-      Assert-SafeArgument -Name "WazuhConfigPath" -Value $configPath -Required $true
-
-      $managerAddresses = @(Get-ManagerAddresses -ManagerList $manager)
-      $manager = $managerAddresses -join ","
-
-      if ([string]::IsNullOrWhiteSpace($registrationServer)) {
-        $registrationServer = $managerAddresses[0]
-      } else {
-        $registrationServerAddresses = @(Get-CommaSeparatedValues -Name "RegistrationServer" -Value $registrationServer)
-        if ($registrationServerAddresses.Count -gt 1) {
-          throw "RegistrationServer must contain a single address. Use ManagerIP for comma-separated manager addresses."
-        }
-
-        $registrationServer = $registrationServerAddresses[0]
-      }
-
-      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
-        $agentGroup = (@(Get-CommaSeparatedValues -Name "AgentGroup" -Value $agentGroup) -join ",")
-      }
-
-      if (-not (Test-Path -LiteralPath $msiPath)) {
-        throw "WazuhAgentMSI tool was not fetched to '$msiPath'."
-      }
-
-      $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msiPath).Hash.ToLowerInvariant()
-
-      $msiArguments = @(
+      LET MsiArgs <= filter(list=(
+        "msiexec.exe",
         "/i",
-        (Quote-ProcessArgument -Value $msiPath),
+        WazuhMSI.FullPath[0],
         "/qn",
         "/norestart",
         "/l*v",
-        (Quote-ProcessArgument -Value $installLog),
-        (New-MsiPropertyArgument -Name "WAZUH_MANAGER" -Value $manager),
-        (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_SERVER" -Value $registrationServer)
-      )
+        LogPath,
+        "WAZUH_MANAGER=" + ManagerFinal,
+        "WAZUH_REGISTRATION_SERVER=" + RegistrationServerFinal,
+        if(condition=ReinstallExistingAgent, then="REINSTALL=ALL"),
+        if(condition=ReinstallExistingAgent, then="REINSTALLMODE=vomus"),
+        if(condition=RegistrationPassword, then="WAZUH_REGISTRATION_PASSWORD=" + RegistrationPassword),
+        if(condition=AgentName, then="WAZUH_AGENT_NAME=" + AgentName),
+        if(condition=AgentGroupFinal, then="WAZUH_AGENT_GROUP=" + AgentGroupFinal)
+      ), regex=".+")
 
-      if (-not [string]::IsNullOrWhiteSpace($registrationPassword)) {
-        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_REGISTRATION_PASSWORD" -Value $registrationPassword)
-      }
+      LET Run <= SELECT *
+      FROM if(
+        condition=ValidationError,
+        then={
+          SELECT "" AS Stdout,
+            ValidationError AS Stderr,
+            1 AS ReturnCode,
+            true AS Complete
+          FROM scope()
+        },
+        else={
+          SELECT *
+          FROM execve(argv=MsiArgs, length=1000000)
+        })
 
-      if (-not [string]::IsNullOrWhiteSpace($agentName)) {
-        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_NAME" -Value $agentName)
-      }
+      LET ServiceActions <= SELECT *
+      FROM if(
+        condition=StartService AND Run.ReturnCode[0] = 0,
+        then={
+          SELECT *
+          FROM chain(
+            stop={
+              SELECT "stop" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["sc.exe", "stop", "WazuhSvc"], length=100000)
+            },
+            wait={
+              SELECT "wait" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["ping.exe", "-n", "6", "127.0.0.1"], length=100000)
+            },
+            start={
+              SELECT "start" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["sc.exe", "start", "WazuhSvc"], length=100000)
+            },
+            query={
+              SELECT "query" AS Action, Stdout, Stderr, ReturnCode, Complete
+              FROM execve(argv=["sc.exe", "query", "WazuhSvc"], length=100000)
+            })
+        })
 
-      if (-not [string]::IsNullOrWhiteSpace($agentGroup)) {
-        $msiArguments += (New-MsiPropertyArgument -Name "WAZUH_AGENT_GROUP" -Value $agentGroup)
-      }
+      LET ServiceSummary <= SELECT *
+      FROM foreach(row=ServiceActions)
 
-      $process = Start-Process `
-        -FilePath "msiexec.exe" `
-        -ArgumentList $msiArguments `
-        -Wait `
-        -PassThru
-
-      if ($process.ExitCode -ne 0) {
-        throw "msiexec.exe failed with exit code $($process.ExitCode)."
-      }
-
-      $configUpdated = $false
-      $configUpdateStatus = "not_requested"
-      if ($updateExistingConfig -and (Test-Path -LiteralPath $configPath)) {
-        [xml]$config = Get-Content -LiteralPath $configPath
-        $root = $config.SelectSingleNode("/ossec_config")
-        if ($null -eq $root) {
-          throw "Unable to update '$configPath': missing /ossec_config root element."
-        }
-
-        $client = $config.SelectSingleNode("/ossec_config/client")
-        if ($null -eq $client) {
-          $client = $config.CreateElement("client")
-          [void]$root.AppendChild($client)
-          $configUpdated = $true
-        }
-
-        $servers = @($client.SelectNodes("server"))
-        if ($servers.Count -eq 0) {
-          $server = $config.CreateElement("server")
-          [void]$client.AppendChild($server)
-          $servers = @($server)
-          $configUpdated = $true
-        }
-
-        $template = $servers[0]
-        for ($i = 0; $i -lt $managerAddresses.Count; $i++) {
-          if ($i -lt $servers.Count) {
-            $server = $servers[$i]
-          } else {
-            $server = $template.CloneNode($true)
-            [void]$client.AppendChild($server)
-            $configUpdated = $true
-          }
-
-          $address = $server.SelectSingleNode("address")
-          if ($null -eq $address) {
-            $address = $config.CreateElement("address")
-            if ($server.HasChildNodes) {
-              [void]$server.InsertBefore($address, $server.FirstChild)
-            } else {
-              [void]$server.AppendChild($address)
-            }
-            $configUpdated = $true
-          }
-
-          if ($address.InnerText -ne $managerAddresses[$i]) {
-            $address.InnerText = $managerAddresses[$i]
-            $configUpdated = $true
-          }
-        }
-
-        if ($servers.Count -gt $managerAddresses.Count) {
-          for ($i = $servers.Count - 1; $i -ge $managerAddresses.Count; $i--) {
-            [void]$client.RemoveChild($servers[$i])
-            $configUpdated = $true
-          }
-        }
-
-        if ($configUpdated) {
-          $config.Save($configPath)
-          $configUpdateStatus = "updated"
-        } else {
-          $configUpdateStatus = "already_current"
-        }
-      } elseif ($updateExistingConfig) {
-        $configUpdateStatus = "missing_config"
-      }
-
-      $serviceStatus = "not_requested"
-      if ($startService) {
-        $service = Get-Service -Name "WazuhSvc" -ErrorAction Stop
-        if ($service.Status -eq "Running") {
-          Restart-Service -Name "WazuhSvc" -Force -ErrorAction Stop
-        } else {
-          Start-Service -Name "WazuhSvc" -ErrorAction Stop
-        }
-
-        $serviceStatus = (Get-Service -Name "WazuhSvc" -ErrorAction Stop).Status.ToString()
-      }
-
-      [ordered]@{
-        Status = "Installed"
-        ManagerIP = $manager
-        RegistrationServer = $registrationServer
-        RegistrationPasswordSupplied = -not [string]::IsNullOrWhiteSpace($registrationPassword)
-        AgentName = $agentName
-        AgentGroup = $agentGroup
-        MsiPath = $msiPath
-        MsiSha256 = $actualSha256
-        MsiExitCode = $process.ExitCode
-        ConfigPath = $configPath
-        ConfigUpdated = $configUpdated
-        ConfigUpdateStatus = $configUpdateStatus
-        ServiceStatus = $serviceStatus
-        InstallLog = $installLog
-      } | ConvertTo-Json -Compress
-      '''
-
-      LET Run <= SELECT Stdout, Stderr, ReturnCode, Complete
-      FROM execve(
-        argv=[
-          "powershell.exe",
-          "-NoProfile",
-          "-NonInteractive",
-          "-ExecutionPolicy", "Bypass",
-          "-Command", PowershellScript
-        ],
-        env=EnvVars,
-        length=1000000
-      )
+      LET ServiceStatus <= if(
+        condition=StartService AND Run.ReturnCode[0] = 0,
+        then=ServiceSummary.Stdout[-1],
+        else="not_requested")
 
       LET LogUpload <= SELECT upload(file=OSPath) AS Upload
       FROM glob(globs=LogPath)
@@ -351,19 +169,20 @@ sources:
 
       SELECT Stdout, Stderr, ReturnCode, Complete,
         LogUpload.Upload[0] AS InstallLog,
+        ServiceSummary AS ServiceActions,
         dict(
-          ManagerIP=ManagerIP,
-          RegistrationServer=RegistrationServer,
+          ManagerIP=ManagerFinal,
+          RegistrationServer=RegistrationServerFinal,
           RegistrationPasswordSupplied=if(condition=RegistrationPassword, then=true, else=false),
           AgentName=AgentName,
-          AgentGroup=AgentGroup,
+          AgentGroup=AgentGroupFinal,
           WazuhAgentMSI=dict(
             Name=WazuhMSI.Name[0],
             DownloadStatus=WazuhMSI.DownloadStatus[0],
             Sha256=WazuhMSI.Hash[0].SHA256
           ),
-          UpdateExistingConfig=UpdateExistingConfig,
-          WazuhConfigPath=WazuhConfigPath,
-          StartService=StartService
+          ReinstallExistingAgent=ReinstallExistingAgent,
+          StartService=StartService,
+          ServiceStatus=ServiceStatus
         ) AS RequestedSettings
       FROM Run

--- a/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
+++ b/content/exchange/artifacts/Windows.Install.Wazuh.Agent.yaml
@@ -26,8 +26,11 @@ precondition: SELECT OS From info() where OS = 'windows'
 
 parameters:
   - name: ManagerIP
-    description: Wazuh manager IP address or hostname. This is required.
-    default: ""
+    type: csv
+    description: Wazuh manager IP address or hostname. This is required. Add one manager per row.
+    default: |
+      IP
+      127.0.0.1
   - name: RegistrationServer
     description: Optional Wazuh registration server. If empty, the first ManagerIP address is used.
     default: ""
@@ -38,8 +41,11 @@ parameters:
     description: Optional Wazuh agent name. If empty, Wazuh uses its default agent naming behavior.
     default: ""
   - name: AgentGroup
-    description: Optional Wazuh agent group or comma-separated groups.
-    default: ""
+    type: csv
+    description: Optional Wazuh agent groups. Add one group per row.
+    default: |
+      Group
+      ""
   - name: ReinstallExistingAgent
     type: bool
     description: Reapply MSI properties when the Wazuh agent is already installed.
@@ -59,7 +65,7 @@ sources:
       LET TempDir <= tempdir()
       LET LogPath <= TempDir + "\\wazuh-agent-install.log"
 
-      LET WazuhMSI <= SELECT FullPath, Name, DownloadStatus, Hash
+      LET WazuhMSI = SELECT FullPath, Name, DownloadStatus, Hash
       FROM Artifact.Generic.Utils.FetchBinary(
         ToolName="WazuhAgentMSI",
         IsExecutable=FALSE
@@ -70,26 +76,26 @@ sources:
         re="^\\s+|\\s+$",
         replace="")
 
-      LET ManagerAddresses <= SELECT Trim(Value=_value) AS Address
-      FROM foreach(row=split(string=ManagerIP, sep=","))
-      WHERE Address
+      LET ManagerAddresses = SELECT Trim(Value=IP) AS IP
+      FROM ManagerIP
+      WHERE IP
 
-      LET RegistrationServerAddresses <= SELECT Trim(Value=_value) AS Address
+      LET RegistrationServerAddresses = SELECT Trim(Value=_value) AS Address
       FROM foreach(row=split(string=RegistrationServer, sep=","))
       WHERE Address
 
-      LET AgentGroups <= SELECT Trim(Value=_value) AS GroupName
-      FROM foreach(row=split(string=AgentGroup, sep=","))
-      WHERE GroupName
+      LET AgentGroups = SELECT Trim(Value=Group) AS Group
+      FROM AgentGroup
+      WHERE Group
 
-      LET ManagerFinal <= join(array=ManagerAddresses.Address, sep=",")
-      LET RegistrationServerFinal <= if(
+      LET ManagerFinal = join(array=ManagerAddresses.IP, sep=",")
+      LET RegistrationServerFinal = if(
         condition=RegistrationServerAddresses.Address[0],
         then=RegistrationServerAddresses.Address[0],
-        else=ManagerAddresses.Address[0])
-      LET AgentGroupFinal <= join(array=AgentGroups.GroupName, sep=",")
+        else=ManagerAddresses.IP[0])
+      LET AgentGroupFinal = join(array=AgentGroups.Group, sep=",")
 
-      LET ValidationError <= if(
+      LET ValidationError = if(
         condition=NOT ManagerFinal,
         then="ManagerIP is required.",
         else=if(
@@ -99,7 +105,7 @@ sources:
             condition=NOT WazuhMSI.FullPath[0],
             then="WazuhAgentMSI tool was not fetched.")))
 
-      LET MsiArgs <= filter(list=(
+      LET MsiArgs = filter(list=(
         "msiexec.exe",
         "/i",
         WazuhMSI.FullPath[0],
@@ -109,14 +115,14 @@ sources:
         LogPath,
         "WAZUH_MANAGER=" + ManagerFinal,
         "WAZUH_REGISTRATION_SERVER=" + RegistrationServerFinal,
-        if(condition=ReinstallExistingAgent, then="REINSTALL=ALL"),
-        if(condition=ReinstallExistingAgent, then="REINSTALLMODE=vomus"),
-        if(condition=RegistrationPassword, then="WAZUH_REGISTRATION_PASSWORD=" + RegistrationPassword),
-        if(condition=AgentName, then="WAZUH_AGENT_NAME=" + AgentName),
-        if(condition=AgentGroupFinal, then="WAZUH_AGENT_GROUP=" + AgentGroupFinal)
+        ReinstallExistingAgent && "REINSTALL=ALL",
+        ReinstallExistingAgent && "REINSTALLMODE=vomus",
+        RegistrationPassword && "WAZUH_REGISTRATION_PASSWORD=" + RegistrationPassword,
+        AgentName && "WAZUH_AGENT_NAME=" + AgentName,
+        AgentGroupFinal && "WAZUH_AGENT_GROUP=" + AgentGroupFinal
       ), regex=".+")
 
-      LET Run <= SELECT *
+      LET Run = SELECT *
       FROM if(
         condition=ValidationError,
         then={
@@ -131,7 +137,7 @@ sources:
           FROM execve(argv=MsiArgs, length=1000000)
         })
 
-      LET ServiceActions <= SELECT *
+      LET ServiceActions = SELECT *
       FROM if(
         condition=StartService AND Run.ReturnCode[0] = 0,
         then={
@@ -140,10 +146,7 @@ sources:
             stop={
               SELECT "stop" AS Action, Stdout, Stderr, ReturnCode, Complete
               FROM execve(argv=["sc.exe", "stop", "WazuhSvc"], length=100000)
-            },
-            wait={
-              SELECT "wait" AS Action, Stdout, Stderr, ReturnCode, Complete
-              FROM execve(argv=["ping.exe", "-n", "6", "127.0.0.1"], length=100000)
+              WHERE sleep(time=6)
             },
             start={
               SELECT "start" AS Action, Stdout, Stderr, ReturnCode, Complete
@@ -155,15 +158,15 @@ sources:
             })
         })
 
-      LET ServiceSummary <= SELECT *
+      LET ServiceSummary = SELECT *
       FROM foreach(row=ServiceActions)
 
-      LET ServiceStatus <= if(
+      LET ServiceStatus = if(
         condition=StartService AND Run.ReturnCode[0] = 0,
         then=ServiceSummary.Stdout[-1],
         else="not_requested")
 
-      LET LogUpload <= SELECT upload(file=OSPath) AS Upload
+      LET LogUpload = SELECT upload(file=OSPath) AS Upload
       FROM glob(globs=LogPath)
       WHERE UploadInstallLog
 


### PR DESCRIPTION
Windows Velociraptor artifact to install and configure the Wazuh agent.

I like to roll out Velociraptor during IR and being able to also install Wazhuh from there would be great.

The artifact supports installing the latest Wazuh Windows agent by resolving the GitHub release/package URL, or pinning a specific agent version with WazuhVersion, which is useful if the host has an already older version of Wazuh running. It also allows overriding the MSI URL directly and optionally validating the downloaded MSI with a SHA256 hash.

- Installs the Wazuh Windows agent silently via msiexec
- Configure Wazuh manager IP
- Supports optional RegistrationServer, RegistrationPassword, AgentName, and AgentGroup
- Supports comma-separated manager addresses
- Allows setting of a specific version
- Allows MsiUrl override in case own hosted
- Optionally updates existing ossec.conf
- Starts or restarts WazuhSvc
- Uploads the MSI install log for troubleshooting
- Tested against a Windows Velociraptor client and Wazuh manager
- Confirmed the Wazuh agent installed, connected, and appeared in the Wazuh dashboard

Feedback welcome!