### PR TITLE
Do not use hard-coded binary version: Fetch latest release

### DIFF
--- a/.github/workflows/spellchecker.yml
+++ b/.github/workflows/spellchecker.yml
@@ -14,19 +14,29 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Download Latest Velociraptor
-        uses: robinraju/release-downloader@v1
-        id: velociraptor
-        with:
-          repository: velocidex/velociraptor
-          tag: v0.76
-          fileName: "velociraptor-v0.76.1-linux-amd64-musl"
-          out-file-path: tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Velociraptor is released on GitHub only for changes to its
+          # minor version number. The same release (e.g.
+          # releases/tag/v0.76) is (re-)used for patch releases.
+          # Retrieve the latest patch release for the latest release:
+          mkdir -p tests
+          url=$(gh api repos/Velocidex/velociraptor/releases/latest \
+            --jq '[.assets[] | select(.name | test("^velociraptor-v\\d+\\.\\d+\\.\\d+-linux-amd64-musl$"))]
+                  | sort_by(.name | capture("v(?<maj>\\d+)\\.(?<min>\\d+)\\.(?<patch>\\d+)")
+                  | [.maj, .min, .patch] | map(tonumber))
+                  | last.browser_download_url')
+          if [ -z "$url" ] || [ "$url" = "null" ]; then
+            echo "No matching velociraptor-vX.Y.Z-linux-amd64-musl asset in latest release" >&2
+            exit 1
+          fi
+          echo "Downloading $url"
+          curl -fsSL "$url" -o tests/velociraptor
+          chmod +x tests/velociraptor
 
       - name: Verify Exchange Artifacts
-        run: |
-          mv ${{ fromJson(steps.velociraptor.outputs.downloaded_files)[0]}} ./tests/velociraptor
-          chmod +x ./tests/velociraptor
-          ./tests/velociraptor -v artifacts verify ./content/exchange/artifacts/*.yaml
+        run: ./tests/velociraptor -v artifacts verify ./content/exchange/artifacts/*.yaml
 
       - uses: rojopolis/spellcheck-github-actions@0.35.0
         name: Spellcheck

--- a/scripts/exchange_verify.py
+++ b/scripts/exchange_verify.py
@@ -1,5 +1,6 @@
 import urllib.request
 import os.path
+import re
 import subprocess
 import json
 import sys
@@ -27,9 +28,32 @@ Datastore:
 VELO_CONFIG_FILENAME = "/tmp/velo.config.yaml"
 
 VELO_FILENAME = "/tmp/velociraptor"
-VELO_URL = "https://github.com/Velocidex/velociraptor/releases/download/v0.76/velociraptor-v0.76.1-linux-amd64-musl"
+VELO_API = "https://api.github.com/repos/Velocidex/velociraptor/releases/latest"
+VELO_ASSET_RE = re.compile(r"^velociraptor-v(\d+)\.(\d+)\.(\d+)-linux-amd64-musl$")
 EXCHANGE_PATH = os.path.abspath("./content/exchange/artifacts/")
 VELO_LOGFILE = "/tmp/velo.log"
+
+# Velociraptor is released on GitHub only for changes to its minor version number.
+# The same release (e.g. releases/tag/v0.76) is (re-)used for patch releases.
+# Retrieve the latest patch release for the latest release:
+def resolve_velo_url():
+    with urllib.request.urlopen(VELO_API) as r:
+        release = json.load(r)
+
+    candidates = []
+    for asset in release["assets"]:
+        m = VELO_ASSET_RE.match(asset["name"])
+        if m:
+            version = tuple(int(x) for x in m.groups())
+            candidates.append((version, asset["browser_download_url"]))
+
+    if not candidates:
+        raise RuntimeError(
+            "No velociraptor-vX.Y.Z-linux-amd64-musl asset found in latest release")
+
+    return max(candidates)[1]
+
+VELO_URL = resolve_velo_url()
 
 # Verify artifact contains correct file extension
 # Skip other specific file types


### PR DESCRIPTION
When I use "bleeding edge" features, actions fail because old tools are used, e.g. in [spellchecker](https://github.com/Velocidex/velociraptor-docs/blob/master/.github/workflows/spellchecker.yml#L22) and [exchange_verify](https://github.com/Velocidex/velociraptor-docs/blob/master/scripts/exchange_verify.py#L30).

I updated these two references last time, but doing so for every release feels very manual. This merge request adds a little bit of logic that fetches the latest patch release (e.g. 0.76.**5**) from the latest release (0.76). There is no argument against using the latest release?

I replaced robinraju/release-downloader@v1 with some simple inline bash. This removes a third-party dependency and with `jq` we can do the necessary filtering and version comparison.

I have tested most of the logic, but I cannot test the full pipeline in GitHub Actions.