### PR TITLE
Add community and third-party training section

### DIFF
--- a/content/training/_index.md
+++ b/content/training/_index.md
@@ -13,6 +13,27 @@ description: |
 
 _We currently have no courses scheduled._
 
+## Community and third-party training
+
+The courses below are run by third parties, not by the Velociraptor project.
+Entries are listed alphabetically by course title.
+
+### Threat Hunting & Incident Response with Velociraptor
+
+_Digital Defense Institute. Two days, offered live at conferences and
+on-demand._
+
+Covers Velociraptor end to end: deploying a server, rolling agents out across
+a fleet, and writing VQL artifacts, then applying those skills to a full
+intrusion. Topics include hunts, notebooks and stacking analysis at scale,
+Sigma over event logs, scoping a compromise, proving execution with Prefetch
+and ShimCache, extracting C2 beacon configuration from memory, and
+coordinated fleet-wide eradication. Includes 16 hands-on labs on cloud-hosted
+lab VMs, each with a video walkthrough. Taught by Eric Capuano and Whitney
+Champion.
+
+[Course details and enrollment](https://academy.digitaldefenseinstitute.com/courses/225936b9-6eec-4838-aae4-5dc65274179b)
+
 ## Training course slides
 
 Click [here](https://training.velociraptor.app/) to view in a new tab.


### PR DESCRIPTION
The Training page currently dead-ends at "We currently have no courses
scheduled," which leaves readers looking for Velociraptor training with
nowhere to go.

This adds a "Community and third-party training" section directly beneath
it, with a stated ordering rule so future entries have an obvious home, and
seeds it with one course.

Mike mentioned in Discord that he points people at DDI's THVR course when
they ask about Velociraptor training, which prompted this PR. Happy to
adjust the wording, drop the instructor credit, or move the section lower on
the page — and equally happy to see other providers' courses listed
alongside it.

Full disclosure: I'm one of the THVR instructors.

Verified locally with `vale --minAlertLevel=error` (clean) and a full `hugo`
build.
