### PR TITLE
Server-side Sigma/Hayabusa analysis of collected EVTX (VQL-native successor to #1064)

### DIFF
--- a/content/exchange/artifacts/Server.Analysis.Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Server.Analysis.Windows.EventLogs.Hayabusa.yaml
@@ -1,0 +1,180 @@
+name: Server.Analysis.Windows.EventLogs.Hayabusa
+author: Whitney Champion - bluesky @whit.zip, Eric Capuano - bluesky @eric.zip
+description: |
+  Runs the curated Hayabusa Sigma ruleset against Windows event logs
+  that were already uploaded to the server by a completed collection
+  flow, using Velociraptor's built-in Sigma engine. No Hayabusa binary
+  is deployed to the endpoint or the server - the entire analysis runs
+  in VQL on the server side.
+
+  This artifact is intended to post-process collections that upload
+  `.evtx` files, such as `Windows.KapeFiles.Targets` or
+  `Windows.Triage.Targets` (or any other collection that uploads raw
+  event logs). It copies the collected EVTX files out of the server's
+  file store into a temporary directory, then evaluates the
+  `Windows.Hayabusa.Rules` artifact over that directory.
+
+  **Prerequisite**: The curated Hayabusa Sigma package must be imported
+  into the server first so that the `Windows.Hayabusa.Rules` artifact
+  resolves. Import it using the built-in `Server.Import.CuratedSigma`
+  artifact on Velociraptor 0.74, or `Server.Import.Extras` on 0.75 and
+  later. The curated packages are published at
+  https://sigma.velocidex.com/. If the package is missing at runtime
+  this artifact logs an error and returns no rows.
+
+  This artifact can be called from within another artifact:
+
+    `SELECT * FROM Artifact.Server.Analysis.Windows.EventLogs.Hayabusa(ClientId=..., FlowId=...)`
+
+  Notes:
+
+  - Requires Velociraptor 0.74 or later.
+  - The analysis needs temporary disk space on the server roughly equal
+    to the decompressed size of the collected EVTX set. The temporary
+    directory is removed automatically when the collection completes.
+  - Uploaded files are flattened to their basename in the temporary
+    directory because the Sigma log sources read fixed channel
+    filenames directly under `ROOT` (for example `Security.evtx`).
+    Only standard-named channel files are scanned. If the same channel
+    file was uploaded more than once (for example from volume shadow
+    copies), the live-volume copy is preferred and duplicates are
+    skipped with a log message.
+  - If `security.allowed_file_accessor_prefix` is configured on the
+    server, the temporary directory must fall under an allowed prefix.
+
+  #sigma #hayabusa #evtx #triage #postprocessing
+
+type: SERVER
+
+reference:
+  - https://sigma.velocidex.com/
+  - https://github.com/Velocidex/velociraptor-docs/pull/1064
+
+required_permissions:
+  - SERVER_ADMIN
+
+parameters:
+  - name: ClientId
+    description: The client ID that the flow was collected from. Required.
+    default:
+  - name: FlowId
+    description: The flow ID of the completed collection containing uploaded EVTX files. Required.
+    default:
+  - name: EvtxRegex
+    description: Only uploaded files with paths matching this regex are analyzed.
+    type: regex
+    default: '(?i)\.evtx$'
+  - name: RuleLevel
+    description: Minimum Sigma rule level to match.
+    type: choices
+    default: Critical and High
+    choices:
+      - "Critical"
+      - "Critical and High"
+      - "Critical, High, and Medium"
+      - "Critical, High, Medium, and Low"
+      - "All"
+  - name: RuleStatus
+    description: Sigma rule status filter.
+    type: choices
+    default: Stable
+    choices:
+      - Stable
+      - Stable and Experimental
+      - Stable and Test
+      - All Rules
+  - name: RuleTitleFilter
+    description: Use this to filter only some rules to match by title.
+    type: regex
+    default: .
+  - name: DateAfter
+    description: "Search for events after this date. YYYY-MM-DDTmm:hh:ss Z"
+    type: timestamp
+  - name: DateBefore
+    description: "Search for events before this date. YYYY-MM-DDTmm:hh:ss Z"
+    type: timestamp
+
+sources:
+  - query: |
+      LET _CheckArgs <= if(condition=NOT ClientId OR NOT FlowId,
+          then=log(message="ClientId and FlowId are required parameters",
+                   level="ERROR"))
+
+      -- The curated artifact is resolved at runtime so this artifact
+      -- loads even before the curated Sigma package has been imported,
+      -- but fail loudly if it is actually missing at execution time.
+      LET HaveRules <= SELECT name
+        FROM artifact_definitions(names="Windows.Hayabusa.Rules")
+      LET _CheckRules <= if(condition=NOT HaveRules,
+          then=log(message="The Windows.Hayabusa.Rules artifact is not installed. Import the curated Sigma package first (Server.Import.CuratedSigma on 0.74, Server.Import.Extras on 0.75+). See https://sigma.velocidex.com/",
+                   level="ERROR"))
+
+      -- A temporary directory to stage the EVTX files. It is removed
+      -- automatically when the scope closes at the end of collection.
+      LET TmpDir <= tempdir()
+
+      LET Fqdn <= client_info(client_id=ClientId).os_info.fqdn
+
+      -- Enumerate the EVTX files uploaded by the flow. The vfs_path
+      -- column is a file store path spec usable with the fs accessor.
+      -- Fall back to the file store path when the original endpoint
+      -- path is not recorded in the uploads metadata.
+      LET AllEvtx <= SELECT vfs_path,
+                            client_path,
+                            file_size,
+                            basename(path=client_path || format(format="%v", args=vfs_path)) AS BaseName,
+                            client_path =~ '''(?i)GLOBALROOT|HarddiskVolumeShadowCopy''' AS IsVSS
+        FROM uploads(client_id=ClientId, flow_id=FlowId)
+        WHERE NOT Type = "idx"
+          AND (client_path || format(format="%v", args=vfs_path)) =~ EvtxRegex
+
+      -- The Sigma log sources read fixed channel filenames directly
+      -- under ROOT, so staged files are flattened to their basename.
+      -- When the same channel file was uploaded more than once (e.g.
+      -- volume shadow copies), prefer the live-volume copy.
+      LET LiveFiles <= SELECT * FROM AllEvtx WHERE NOT IsVSS GROUP BY BaseName
+      LET VSSFiles <= SELECT * FROM AllEvtx
+        WHERE IsVSS AND NOT BaseName IN LiveFiles.BaseName
+        GROUP BY BaseName
+      LET EvtxFiles <= SELECT * FROM chain(a=LiveFiles, b=VSSFiles)
+
+      LET _CheckDupes <= if(condition=len(list=AllEvtx) > len(list=EvtxFiles),
+          then=log(message=format(
+              format="Skipped %v duplicate channel file(s) with the same name - kept live-volume copies",
+              args=[len(list=AllEvtx) - len(list=EvtxFiles)])))
+
+      LET _CheckEmpty <= if(condition=NOT AllEvtx,
+          then=log(message=format(
+              format="No uploaded files matching %v found in flow %v - nothing to scan",
+              args=[EvtxRegex, FlowId])))
+
+      -- Copy each file into the temporary directory. The fs accessor
+      -- reads through the file store API and transparently decompresses
+      -- compressed uploads.
+      LET _Staged <= SELECT BaseName,
+                            file_size,
+                            copy(filename=vfs_path,
+                                 accessor="fs",
+                                 dest=TmpDir + "/" + BaseName) AS StagedPath
+        FROM EvtxFiles
+
+      SELECT * FROM if(
+          condition=ClientId AND FlowId AND HaveRules AND _Staged,
+          then={
+        SELECT ClientId,
+               FlowId,
+               Fqdn,
+               *
+        FROM collect(artifacts="Windows.Hayabusa.Rules",
+                     args=dict(`Windows.Hayabusa.Rules`=dict(
+                         ROOT=TmpDir,
+                         RuleLevel=RuleLevel,
+                         RuleStatus=RuleStatus,
+                         RuleTitleFilter=RuleTitleFilter,
+                         DateAfter=DateAfter,
+                         DateBefore=DateBefore)))
+      })
+
+column_types:
+  - name: Timestamp
+    type: timestamp

--- a/content/exchange/artifacts/Server.Monitor.Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Server.Monitor.Windows.EventLogs.Hayabusa.yaml
@@ -1,0 +1,105 @@
+name: Server.Monitor.Windows.EventLogs.Hayabusa
+author: Whitney Champion - bluesky @whit.zip, Eric Capuano - bluesky @eric.zip
+description: |
+  Watches for completed client collections whose artifacts match
+  `ArtifactRegex` and automatically runs
+  `Server.Analysis.Windows.EventLogs.Hayabusa` against the EVTX files
+  uploaded by each flow. Detection results appear under Server Events
+  for this artifact.
+
+  By default this triggers on `Windows.KapeFiles.Targets` and
+  `Windows.Triage.Targets`, the most common triage collections that
+  upload raw Windows event logs. Adjust `ArtifactRegex` to match any
+  other collection that uploads `.evtx` files.
+
+  **Prerequisites**:
+
+  - The companion `Server.Analysis.Windows.EventLogs.Hayabusa` exchange
+    artifact must be installed on the server - this artifact only
+    triggers it.
+  - The curated Hayabusa Sigma package must be imported into the
+    server so that the `Windows.Hayabusa.Rules` artifact resolves.
+    Import it using the built-in `Server.Import.CuratedSigma` artifact
+    on Velociraptor 0.74, or `Server.Import.Extras` on 0.75 and later.
+    The curated packages are published at https://sigma.velocidex.com/.
+
+  Notes:
+
+  - Analysis runs inline within the monitoring query, so processing is
+    serialized: a long-running scan of a large EVTX set will queue
+    subsequent flow completions until it finishes.
+  - Add this artifact to server monitoring via the Server Events screen
+    in the GUI.
+  - Requires Velociraptor 0.74 or later.
+
+  #sigma #hayabusa #evtx #triage #postprocessing
+
+type: SERVER_EVENT
+
+reference:
+  - https://sigma.velocidex.com/
+  - https://github.com/Velocidex/velociraptor-docs/pull/1064
+
+required_permissions:
+  - SERVER_ADMIN
+
+parameters:
+  - name: ArtifactRegex
+    description: Trigger analysis when a completed flow contains artifacts matching this regex.
+    type: regex
+    default: 'Windows\.KapeFiles\.Targets|Windows\.Triage\.Targets'
+  - name: EvtxRegex
+    description: Only uploaded files with paths matching this regex are analyzed.
+    type: regex
+    default: '(?i)\.evtx$'
+  - name: RuleLevel
+    description: Minimum Sigma rule level to match.
+    type: choices
+    default: Critical and High
+    choices:
+      - "Critical"
+      - "Critical and High"
+      - "Critical, High, and Medium"
+      - "Critical, High, Medium, and Low"
+      - "All"
+  - name: RuleStatus
+    description: Sigma rule status filter.
+    type: choices
+    default: Stable
+    choices:
+      - Stable
+      - Stable and Experimental
+      - Stable and Test
+      - All Rules
+  - name: RuleTitleFilter
+    description: Use this to filter only some rules to match by title.
+    type: regex
+    default: .
+
+sources:
+  - query: |
+      -- Watch for completed client collections that produced results
+      -- for artifacts matching ArtifactRegex.
+      LET Completions = SELECT ClientId,
+                               FlowId
+        FROM watch_monitoring(artifact="System.Flow.Completion")
+        WHERE ClientId != "server"
+          AND Flow.artifacts_with_results =~ ArtifactRegex
+
+      -- Run the analysis artifact for each matching completion.
+      SELECT *
+      FROM foreach(row=Completions,
+                   query={
+          SELECT *
+          FROM Artifact.Server.Analysis.Windows.EventLogs.Hayabusa(
+              ClientId=ClientId,
+              FlowId=FlowId,
+              EvtxRegex=EvtxRegex,
+              RuleLevel=RuleLevel,
+              RuleStatus=RuleStatus,
+              RuleTitleFilter=RuleTitleFilter)
+        })
+
+column_types:
+  - name: Timestamp
+    type: timestamp

--- a/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
+++ b/content/exchange/artifacts/Windows.EventLogs.Hayabusa.yaml
@@ -4,6 +4,25 @@ description: |
    Windows event log fast forensics timeline generator and threat
    hunting tool.
 
+   **WARNING**: This artifact deploys and executes a third-party binary
+   (`hayabusa.exe`) on the endpoint, which carries significant
+   operational risks:
+
+   * Security tools (AV/EDR) commonly detect, block, or quarantine the
+     Hayabusa binary, which may raise alerts for defenders or interfere
+     with the collection.
+   * The `UpdateRules` option causes the endpoint to make outbound
+     network connections to GitHub.
+   * Running analysis tools on the endpoint modifies forensic state
+     (Prefetch, Amcache, USN journal, etc.).
+
+   In most cases you should prefer Velociraptor's built-in Sigma engine,
+   which evaluates the same Hayabusa ruleset natively without deploying
+   any binary to the endpoint: import the curated `Windows.Hayabusa.Rules`
+   artifact from https://sigma.velocidex.com/ using the built-in
+   `Server.Import.CuratedSigma` artifact on Velociraptor 0.74, or
+   `Server.Import.Extras` on 0.75 and later.
+
    This artifact runs Hayabusa on the endpoint against the specified
    Windows event log directory, and generates and uploads a single CSV/JSONL
    file for further analysis with excel, timeline explorer, elastic


### PR DESCRIPTION
This PR adds server-side analysis of already-collected Windows event logs using Velociraptor's built-in Sigma engine and the curated Hayabusa ruleset — and adds a risk warning to the legacy endpoint-binary artifact.

It resurrects the intent of #1064 (credit to @shortstack for the original design), rebuilt to address each reason that PR was closed:

| #1064 close reason | This PR |
|---|---|
| Raw datastore paths break on 0.75+ (compressed datastore) | Files are staged with `copy(accessor="fs")`, which reads through the file store API and decompresses transparently. No raw paths, no external binary touching the datastore. |
| Should use `uploads()` / `file_store()` instead of path reconstruction | Flow uploads are enumerated with `uploads()`; nothing is reconstructed. |
| "Sigma processing is already built into velociraptor with the Hayabusa ruleset available at https://sigma.velocidex.com" | That is exactly the engine used. No Hayabusa binary is deployed to the endpoint **or** the server — the artifact delegates to the curated `Windows.Hayabusa.Rules` artifact via a runtime `collect()` call, so rules stay current with the curated pack and are never duplicated. |

## What's included

**`Server.Analysis.Windows.EventLogs.Hayabusa`** (SERVER) — takes a `ClientId`/`FlowId` of any completed collection that uploaded `.evtx` files (`Windows.Triage.Targets`, `Windows.KapeFiles.Targets`, etc.), stages the EVTX from the file store into a `tempdir()`, and evaluates the curated Hayabusa ruleset over it. Pass-through tuning: `RuleLevel` (all five upstream tiers), `RuleStatus`, `RuleTitleFilter`, `DateAfter`/`DateBefore`. Results carry `ClientId`/`FlowId`/`Fqdn` context.

Robustness behaviors:
- If the same channel file was uploaded more than once (e.g. volume shadow copies), the live-volume copy is preferred and skipped duplicates are logged.
- Missing curated package, missing `ClientId`/`FlowId`, or a flow with no matching EVTX each log an actionable message and return zero rows rather than failing silently or running the ruleset against nothing.
- Uploads lacking an original endpoint path fall back to their file store filename rather than being silently excluded.

**`Server.Monitor.Windows.EventLogs.Hayabusa`** (SERVER_EVENT) — watches `System.Flow.Completion` and automatically analyzes matching flows (default regex: `Windows\.KapeFiles\.Targets|Windows\.Triage\.Targets`). Results appear under Server Events. Analyses run inline and serialized; this is documented as a deliberate simplicity tradeoff.

**`Windows.EventLogs.Hayabusa`** (existing) — description now carries a warning after the summary paragraph: the deployed binary is commonly flagged/quarantined by AV/EDR, `UpdateRules` makes the endpoint reach out to GitHub, and on-endpoint analysis modifies forensic state — with a pointer to the native alternative. Functionality unchanged.

## Why server-side

Deploying `hayabusa.exe` to endpoints routinely trips third-party security tooling (alerting defenders, quarantining the tool mid-collection) and pollutes endpoint forensic state. Collecting raw EVTX and analyzing centrally avoids all of that, works retroactively on collections already sitting on the server, and needs no per-endpoint tool staging.

## Tested

End-to-end on a Windows Server 2022 VM running Velociraptor **0.77.1** in GUI mode:

- Manual run against a 336-file (~40MB) `Windows.Triage.Targets` EventLogs collection: **604 detections in ~14 seconds**, including `Potentially Malicious PwSh`, `Windows Defender Threat Detected`, `Permanent WMI Event Consumer`.
- Monitor auto-triggered on a fresh flow completion and produced 645 rows into Server Events with no operator action; server logs show the `uploads() → copy(fs://…) → sigma` pipeline executing.
- After a review hardening pass, the full suite was re-run: identical 604-row baseline (no behavioral regression), the `Critical, High, Medium, and Low` tier filters correctly, and all failure-path guards produce clean log messages with zero rows.
- `velociraptor-0.77.1 -v artifacts verify ./content/exchange/artifacts/*yaml` passes (exit 0) with these files included. The dynamic `collect()` invocation is deliberate: a static `Artifact.Windows.Hayabusa.Rules` reference fails `artifacts verify` since the curated artifact is not built-in.

## Notes

- Prerequisite (documented in all descriptions): the curated Sigma package must be imported so `Windows.Hayabusa.Rules` resolves — `Server.Import.CuratedSigma` on 0.74, `Server.Import.Extras` on 0.75+.
- `required_permissions: [SERVER_ADMIN]` (the `fs` accessor requires it).
- Temp disk usage ≈ decompressed size of the collected EVTX set per analysis; the tempdir is removed when the collection completes.
- Only standard-named channel files under the staging directory are scanned (a constraint of the `Windows.Sigma.Base` log-source model).
